### PR TITLE
Trigger Fluent Snippets index rebuild after import

### DIFF
--- a/includes/class-flygit-snippet-manager.php
+++ b/includes/class-flygit-snippet-manager.php
@@ -76,6 +76,8 @@ class FlyGit_Snippet_Manager {
 
         $message = sprintf( __( 'Snippet "%s" imported successfully.', 'flygit' ), $file_name );
 
+        do_action( 'fluent_snippets/rebuild_index', $file_name, true );
+
         return $message;
     }
 


### PR DESCRIPTION
## Summary
- trigger the `fluent_snippets/rebuild_index` action after successfully importing a snippet so the index stays in sync

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cee1b7e4f4832c88ea0f6e2f351de4