### PR TITLE
Revamp snippet import management

### DIFF
--- a/flygit.php
+++ b/flygit.php
@@ -35,7 +35,7 @@ function flygit_init() {
     $installer = new FlyGit_Installer();
     $snippets  = new FlyGit_Snippet_Manager();
     $admin     = new FlyGit_Admin( $installer, $snippets );
-    $webhook   = new FlyGit_Webhook_Handler( $installer );
+    $webhook   = new FlyGit_Webhook_Handler( $installer, $snippets );
 
     $GLOBALS['flygit_installer'] = $installer;
     $GLOBALS['flygit_snippets']  = $snippets;


### PR DESCRIPTION
## Summary
- refactor the snippet manager to import all PHP files from the repository php directory, persist installations and apply the `flygit-` filename prefix
- extend the admin dashboard to surface stored snippet installations, add webhook controls and simplify the import form
- update the webhook handler and bootstrap wiring so snippet installations can be refreshed through the REST endpoint

## Testing
- php -l flygit.php
- php -l includes/class-flygit-admin.php
- php -l includes/class-flygit-snippet-manager.php
- php -l includes/class-flygit-webhook-handler.php
- php -l includes/views/dashboard.php

------
https://chatgpt.com/codex/tasks/task_e_68cee564c2ac832cadffcd18a8c44506