### PR TITLE
Fix snippet header extraction to avoid extra blank line

### DIFF
--- a/includes/class-flygit-snippet-manager.php
+++ b/includes/class-flygit-snippet-manager.php
@@ -758,7 +758,7 @@ class FlyGit_Snippet_Manager {
         }
 
         $header = substr( $content, 0, $closing_tag_pos + 2 );
-        $header = rtrim( $header, "\r\n" ) . "\n\n";
+        $header = rtrim( $header, "\r\n" ) . "\n";
 
         return $header;
     }


### PR DESCRIPTION
## Summary
- ensure the extracted snippet header ends with a single newline when updating stored snippets
- prevent duplicate blank lines from being inserted before the snippet body content

## Testing
- php -l includes/class-flygit-snippet-manager.php

------
https://chatgpt.com/codex/tasks/task_e_68cefbc0a6ec832cb5892c342fd0dde3