### PR TITLE
Adjust snippet header name for Uptime Kuma

### DIFF
--- a/includes/class-flygit-snippet-manager.php
+++ b/includes/class-flygit-snippet-manager.php
@@ -705,9 +705,15 @@ class FlyGit_Snippet_Manager {
         $display_name = pathinfo( $file_name, PATHINFO_FILENAME );
         $timestamp    = current_time( 'mysql' );
 
+        if ( preg_match( '/(^|-)uptime-kuma$/i', $display_name ) ) {
+            $name = 'Uptime Kuma';
+        } else {
+            $name = 'FlyGit ' . $display_name;
+        }
+
         $header = sprintf(
-            "<?php\n// <Internal Doc Start>\n/*\n*\n* @description: \n* @tags: \n* @group: \n* @name: FlyGit %1\$s\n* @type: PHP\n* @status: draft\n* @created_by: 1\n* @created_at: %2\$s\n* @updated_at: \n* @is_valid: 1\n* @updated_by: 1\n* @priority: 10\n* @run_at: all\n* @load_as_file: \n* @condition: {\"status\":\"no\",\"run_if\":\"assertive\",\"items\":[[]]}\n*/\n?>\n<?php if (!defined(\"ABSPATH\")) { return;} // <Internal Doc End> ?>\n",
-            $display_name,
+            "<?php\n// <Internal Doc Start>\n/*\n*\n* @description: \n* @tags: \n* @group: \n* @name: %1\$s\n* @type: PHP\n* @status: draft\n* @created_by: 1\n* @created_at: %2\$s\n* @updated_at: \n* @is_valid: 1\n* @updated_by: 1\n* @priority: 10\n* @run_at: all\n* @load_as_file: \n* @condition: {\"status\":\"no\",\"run_if\":\"assertive\",\"items\":[[]]}\n*/\n?>\n<?php if (!defined(\"ABSPATH\")) { return;} // <Internal Doc End> ?>\n",
+            $name,
             $timestamp
         );
 


### PR DESCRIPTION
## Summary
- special-case snippet header generation for Uptime Kuma so the @name field reads "Uptime Kuma"
- keep the existing FlyGit-prefixed naming for other snippet files

## Testing
- php -l includes/class-flygit-snippet-manager.php

------
https://chatgpt.com/codex/tasks/task_e_68cf02bcbe24832cb1681a10374a3799