### PR TITLE
Allow configuring snippet repository names

### DIFF
--- a/flygit.php
+++ b/flygit.php
@@ -47,6 +47,7 @@ function flygit_init() {
     add_action( 'admin_post_flygit_save_webhook_settings', array( $admin, 'handle_webhook_settings' ) );
     add_action( 'admin_post_flygit_uninstall', array( $admin, 'handle_uninstall_request' ) );
     add_action( 'admin_post_flygit_import_snippet', array( $admin, 'handle_snippet_import_request' ) );
+    add_action( 'admin_post_flygit_update_snippet_settings', array( $admin, 'handle_snippet_settings_request' ) );
     add_action( 'admin_enqueue_scripts', array( $admin, 'enqueue_assets' ) );
 
     add_action( 'rest_api_init', array( $webhook, 'register_routes' ) );

--- a/includes/views/dashboard.php
+++ b/includes/views/dashboard.php
@@ -358,10 +358,11 @@
                     $snippet_uninstall_label = ! empty( $snippet_installation['name'] ) ? $snippet_installation['name'] : $snippet_installation['id'];
                     $snippet_uninstall_message = sprintf( esc_html__( 'Are you sure you want to uninstall the snippet repository "%s"?', 'flygit' ), $snippet_uninstall_label );
                     $snippet_webhook_element_id = 'flygit-webhook-url-' . sanitize_html_class( $snippet_installation['id'] );
+                    $snippet_display_name      = ! empty( $snippet_installation['name'] ) ? $snippet_installation['name'] : ( isset( $snippet_installation['slug'] ) ? $snippet_installation['slug'] : __( 'Snippet Repository', 'flygit' ) );
                     ?>
                     <details class="flygit-item">
                         <summary>
-                            <span class="flygit-item-title"><?php echo esc_html( $snippet_installation['name'] ); ?></span>
+                            <span class="flygit-item-title"><?php echo esc_html( $snippet_display_name ); ?></span>
                             <span class="flygit-item-meta">
                                 <span><?php printf( esc_html__( '%d files', 'flygit' ), $snippet_count ); ?></span>
                                 <?php if ( ! empty( $snippet_last ) ) : ?>
@@ -412,6 +413,17 @@
 
                             <div class="flygit-installation-settings">
                                 <h4><?php esc_html_e( 'FlyGit Settings', 'flygit' ); ?></h4>
+
+                                <form class="flygit-form" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+                                    <?php wp_nonce_field( 'flygit_snippet_settings' ); ?>
+                                    <input type="hidden" name="action" value="flygit_update_snippet_settings" />
+                                    <input type="hidden" name="installation_id" value="<?php echo esc_attr( $snippet_installation['id'] ); ?>" />
+                                    <label>
+                                        <?php esc_html_e( 'Display Name', 'flygit' ); ?>
+                                        <input type="text" name="name" value="<?php echo esc_attr( $snippet_display_name ); ?>" required />
+                                    </label>
+                                    <button type="submit" class="button"><?php esc_html_e( 'Save Name', 'flygit' ); ?></button>
+                                </form>
 
                                 <div class="flygit-installation-webhook">
                                     <span class="flygit-installation-subtitle"><?php esc_html_e( 'Webhook Endpoint', 'flygit' ); ?></span>
@@ -496,6 +508,11 @@
         <form class="flygit-form flygit-snippet-form" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
             <?php wp_nonce_field( 'flygit_import_snippet' ); ?>
             <input type="hidden" name="action" value="flygit_import_snippet" />
+
+            <label>
+                <?php esc_html_e( 'Display Name', 'flygit' ); ?>
+                <input type="text" name="name" placeholder="<?php esc_attr_e( 'Code Snippets', 'flygit' ); ?>" />
+            </label>
 
             <label>
                 <?php esc_html_e( 'Repository URL', 'flygit' ); ?>


### PR DESCRIPTION
## Summary
- allow specifying a custom display name when importing snippet repositories
- add dashboard controls to rename existing snippet repositories and persist the change
- normalize stored snippet names to fall back to meaningful defaults when missing

## Testing
- php -l includes/class-flygit-snippet-manager.php
- php -l includes/views/dashboard.php
- php -l flygit.php
- php -l includes/class-flygit-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68cf0d47a28c832ca1b4b117c2b34773