### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ FlyGit is a WordPress admin plugin that lets you install and manage themes or pl
   - [Webhook automation](#webhook-automation)
   - [Managing existing installs](#managing-existing-installs)
 - [Development notes](#development-notes)
+- [Version history](#version-history)
 - [Troubleshooting](#troubleshooting)
 - [Contributing](#contributing)
 
@@ -81,6 +82,17 @@ Use the **Copy** button next to the webhook URL in the dashboard to avoid typos.
 - Webhook processing is managed by `includes/class-flygit-webhook-handler.php` and registers REST routes under `flygit/v1`.
 
 When contributing code, follow WordPress coding standards and make sure PHP files remain lint-free.
+
+## Version history
+
+### 1.1.0
+
+- Exposes explicit WordPress (6.0+) and PHP (7.4+) requirements in the plugin metadata.
+- Updates this documentation to reflect the 1.1.0 release.
+
+### 1.0.0
+
+- Initial public release of FlyGit with Git-powered theme and plugin installs, webhook automation, and dashboard management tools.
 
 ## Troubleshooting
 

--- a/flygit.php
+++ b/flygit.php
@@ -4,10 +4,20 @@
  * Plugin URI: https://github.com/kevinheinrichs/FlyGit/
  * Description: Install themes and plugins from public and private Git repositories directly within WordPress.
  * Version: 1.1.0
+ * Requires at least: 6.0
+ * Requires PHP: 7.4
  * Author: Kevin Heinrichs
  * Author URI: https://www.kevinheinrichs.com/
  * Text Domain: flygit
  * Domain Path: /languages
+ */
+
+/**
+ * Main plugin bootstrap file.
+ *
+ * @package FlyGit
+ * @since 1.0.0
+ * @version 1.1.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
## Summary
- declare explicit WordPress and PHP requirements in the plugin header for the 1.1.0 release
- document the 1.1.0 release in the README with a version history section

## Testing
- php -l flygit.php

------
https://chatgpt.com/codex/tasks/task_e_68cf18c688c0832c839864a5967c8807