### PR TITLE
Redesign FlyGit dashboard UI

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,393 +1,561 @@
 .flygit-dashboard {
-    max-width: 1200px;
+    max-width: 1280px;
+    margin: 0 auto;
+    padding: 0 0 72px;
     display: grid;
-    gap: 24px;
+    gap: 32px;
 }
 
 .flygit-dashboard .notice {
     margin: 0;
-    border-radius: 12px;
+    border-radius: 18px;
 }
 
-.flygit-hero {
-    background: linear-gradient(135deg, #2271b1, #1a5aa6 55%, #103d75);
+.flygit-dashboard-header {
+    background: linear-gradient(135deg, #2563eb 0%, #4f46e5 45%, #7c3aed 100%);
+    border-radius: 34px;
+    padding: 48px;
     color: #ffffff;
-    border-radius: 20px;
-    padding: 32px;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 24px;
-    align-items: stretch;
-    justify-content: space-between;
     position: relative;
     overflow: hidden;
-    box-shadow: 0 32px 60px -42px rgba(8, 28, 66, 0.7);
+    box-shadow: 0 40px 90px -60px rgba(30, 64, 175, 0.65);
 }
 
-.flygit-hero::after {
+.flygit-dashboard-header::before,
+.flygit-dashboard-header::after {
     content: '';
     position: absolute;
-    inset: -45% 45% 45% -25%;
-    background: radial-gradient(circle at center, rgba(255, 255, 255, 0.24) 0%, rgba(255, 255, 255, 0) 65%);
-    pointer-events: none;
+    border-radius: 999px;
+    filter: blur(0.5px);
+    opacity: 0.6;
 }
 
-.flygit-hero-body {
-    display: grid;
-    gap: 12px;
-    max-width: 540px;
+.flygit-dashboard-header::before {
+    width: 420px;
+    height: 420px;
+    right: -120px;
+    top: -160px;
+    background: radial-gradient(circle at center, rgba(255, 255, 255, 0.38) 0%, rgba(255, 255, 255, 0) 70%);
+}
+
+.flygit-dashboard-header::after {
+    width: 280px;
+    height: 280px;
+    left: 55%;
+    bottom: -140px;
+    background: radial-gradient(circle at center, rgba(255, 255, 255, 0.22) 0%, rgba(255, 255, 255, 0) 70%);
+}
+
+.flygit-header-inner {
     position: relative;
     z-index: 1;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 32px;
+    align-items: stretch;
+    justify-content: space-between;
 }
 
-.flygit-hero-body h1 {
-    margin: 0;
-    font-size: 28px;
+.flygit-header-text {
+    max-width: 520px;
+    display: grid;
+    gap: 16px;
+}
+
+.flygit-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-size: 12px;
     font-weight: 700;
-    color: #ffffff;
+    background: rgba(255, 255, 255, 0.16);
+    border: 1px solid rgba(255, 255, 255, 0.35);
+    border-radius: 999px;
+    padding: 6px 14px;
 }
 
-.flygit-hero-body p {
+.flygit-header-text h1 {
+    margin: 0;
+    font-size: 34px;
+    font-weight: 700;
+    line-height: 1.1;
+}
+
+.flygit-header-text p {
     margin: 0;
     font-size: 16px;
-    line-height: 1.6;
+    line-height: 1.7;
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.flygit-header-meta {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 14px;
+    background: rgba(15, 23, 42, 0.32);
+    border-radius: 16px;
     color: rgba(255, 255, 255, 0.9);
-}
-
-.flygit-hero-meta {
     font-size: 13px;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: rgba(255, 255, 255, 0.75);
+    font-weight: 500;
 }
 
-.flygit-hero-actions {
+.flygit-header-meta .dashicons {
+    font-size: 18px;
+}
+
+.flygit-header-actions {
     display: flex;
     flex-wrap: wrap;
     gap: 12px;
-    align-items: center;
-    justify-content: flex-end;
-    position: relative;
-    z-index: 1;
+    margin-top: 8px;
 }
 
-.flygit-hero-button {
-    display: inline-flex !important;
+.flygit-cta {
+    display: inline-flex;
     align-items: center;
     gap: 8px;
     border-radius: 999px;
-    padding: 10px 18px;
-    border-width: 1px;
-    border-style: solid;
+    padding: 12px 18px;
     font-weight: 600;
-    line-height: 1.2;
-    transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease, color 0.2s ease;
+    color: #ffffff;
+    text-decoration: none;
+    background: rgba(255, 255, 255, 0.14);
+    border: 1px solid rgba(255, 255, 255, 0.28);
 }
 
-.flygit-hero-button .dashicons {
-    font-size: 18px;
-    line-height: 1;
+.flygit-cta .dashicons {
+    font-size: 16px;
 }
 
-.flygit-hero-actions .button-primary.flygit-hero-button {
+.flygit-cta.is-primary {
     background: #ffffff;
-    border-color: #ffffff;
-    color: #163d74;
-    box-shadow: 0 12px 30px -20px rgba(17, 40, 82, 0.75);
+    color: #1e3a8a;
+    border-color: rgba(255, 255, 255, 0.9);
+    box-shadow: 0 22px 40px -26px rgba(30, 64, 175, 0.7);
 }
 
-.flygit-hero-actions .button-primary.flygit-hero-button:hover,
-.flygit-hero-actions .button-primary.flygit-hero-button:focus {
-    background: #f0f6ff;
-    border-color: #f0f6ff;
-    color: #12345a;
-    box-shadow: 0 16px 40px -24px rgba(17, 40, 82, 0.7);
+.flygit-cta:not(.is-primary):hover,
+.flygit-cta:not(.is-primary):focus {
+    background: rgba(255, 255, 255, 0.24);
+    border-color: rgba(255, 255, 255, 0.45);
 }
 
-.flygit-hero-actions .button.flygit-hero-button {
-    background: rgba(255, 255, 255, 0.08);
-    border-color: rgba(255, 255, 255, 0.42);
-    color: #ffffff;
-    box-shadow: none;
+.flygit-cta.is-primary:hover,
+.flygit-cta.is-primary:focus {
+    background: #f8fafc;
+    color: #1d4ed8;
 }
 
-.flygit-hero-actions .button.flygit-hero-button:hover,
-.flygit-hero-actions .button.flygit-hero-button:focus {
-    background: rgba(255, 255, 255, 0.2);
-    border-color: rgba(255, 255, 255, 0.65);
-    color: #ffffff;
-    transform: translateY(-2px);
-}
-
-.flygit-stats-grid {
+.flygit-header-summary {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 18px;
-}
-
-.flygit-stat-card {
-    background: #ffffff;
-    border-radius: 16px;
-    padding: 18px 20px;
-    border: 1px solid #e2e8f0;
-    display: flex;
     gap: 16px;
-    align-items: flex-start;
-    box-shadow: 0 20px 45px -36px rgba(15, 23, 42, 0.7);
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    align-content: start;
 }
 
-.flygit-stat-card:hover,
-.flygit-stat-card:focus-within {
-    transform: translateY(-2px);
-    box-shadow: 0 30px 55px -40px rgba(15, 23, 42, 0.8);
-}
-
-.flygit-stat-icon {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 46px;
-    height: 46px;
-    border-radius: 50%;
-    background: #e7f1fb;
-    color: #1f4e8c;
-    flex-shrink: 0;
-}
-
-.flygit-stat-icon:before {
-    font-size: 22px;
-    line-height: 1;
-}
-
-.flygit-stat-content {
+.flygit-header-stat {
+    background: rgba(15, 23, 42, 0.28);
+    border: 1px solid rgba(255, 255, 255, 0.28);
+    border-radius: 24px;
+    padding: 20px 22px;
     display: grid;
-    gap: 4px;
+    gap: 6px;
+    box-shadow: 0 24px 60px -38px rgba(15, 23, 42, 0.75);
+    backdrop-filter: blur(18px);
 }
 
-.flygit-stat-label {
+.flygit-header-stat-label {
     font-size: 12px;
     text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: #4f5d75;
-    font-weight: 600;
-}
-
-.flygit-stat-value {
-    font-size: 28px;
+    letter-spacing: 0.12em;
+    color: rgba(255, 255, 255, 0.72);
     font-weight: 700;
-    color: #1d2327;
 }
 
-.flygit-stat-sub {
+.flygit-header-stat-value {
+    font-size: 32px;
+    font-weight: 700;
+}
+
+.flygit-header-stat-sub {
     font-size: 13px;
-    color: #4b5563;
+    color: rgba(255, 255, 255, 0.78);
+}
+
+.flygit-alert {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    border-radius: 16px;
+    padding: 14px 18px;
+    font-weight: 500;
+    box-shadow: 0 18px 46px -32px rgba(15, 23, 42, 0.35);
+}
+
+.flygit-alert-success {
+    background: #ecfdf5;
+    border: 1px solid #34d399;
+    color: #047857;
+}
+
+.flygit-alert-error {
+    background: #fef2f2;
+    border: 1px solid #f87171;
+    color: #b91c1c;
+}
+
+.flygit-alert-icon {
+    font-size: 18px;
+}
+
+.flygit-dashboard-content {
+    display: grid;
+    gap: 32px;
 }
 
 .flygit-columns {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+    gap: 32px;
+    grid-template-columns: repeat(auto-fit, minmax(380px, 1fr));
+    align-items: start;
+}
+
+.flygit-card {
+    background: #ffffff;
+    border-radius: 28px;
+    border: 1px solid #e5e9f5;
+    box-shadow: 0 30px 80px -60px rgba(15, 23, 42, 0.25);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.flygit-card--full {
+    grid-column: 1 / -1;
+}
+
+.flygit-card-header {
+    padding: 32px 36px 0;
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+}
+
+.flygit-eyebrow {
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: #6366f1;
+}
+
+.flygit-card-header h2 {
+    margin: 10px 0 0;
+    font-size: 24px;
+    font-weight: 600;
+    color: #111827;
+}
+
+.flygit-counter {
+    align-self: flex-start;
+    background: #eef2ff;
+    border: 1px solid #c7d2fe;
+    color: #3730a3;
+    border-radius: 999px;
+    padding: 6px 14px;
+    font-size: 13px;
+    font-weight: 600;
+}
+
+.flygit-card-body {
+    padding: 32px 36px 36px;
+    display: grid;
     gap: 28px;
 }
 
-.flygit-section {
-    background: #ffffff;
-    border: 1px solid #e3e6ed;
-    border-radius: 18px;
-    overflow: hidden;
-    display: flex;
-    flex-direction: column;
-    min-height: 100%;
-    box-shadow: 0 24px 50px -35px rgba(15, 23, 42, 0.35);
+.flygit-card-body--split {
+    gap: 28px;
 }
 
-.flygit-snippets-section {
-    margin-top: 32px;
+.flygit-card-main {
+    display: grid;
+    gap: 20px;
+    align-content: start;
 }
 
-.flygit-section-header {
-    padding: 20px 24px;
-    border-bottom: 1px solid #e3e6ed;
-    background: linear-gradient(180deg, #f7f9fc 0%, #ffffff 100%);
+.flygit-card-side {
+    display: grid;
 }
 
-.flygit-section-header h2 {
+.flygit-side-card {
+    background: linear-gradient(180deg, #f9fafc 0%, #eef2ff 100%);
+    border: 1px solid #e2e8f0;
+    border-radius: 24px;
+    padding: 28px;
+    display: grid;
+    gap: 18px;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.flygit-side-card h3 {
     margin: 0;
     font-size: 20px;
     font-weight: 600;
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    color: #1d2327;
+    color: #1f2937;
 }
 
-.flygit-badge {
-    background: #ecf3ff;
-    color: #1f4e8c;
-    border-radius: 999px;
-    padding: 2px 12px;
-    font-size: 12px;
-    font-weight: 600;
-    border: 1px solid #c3d7f5;
-}
-
-.flygit-list {
-    padding: 20px 24px;
-    display: grid;
-    gap: 16px;
-}
-
-.flygit-item {
-    border: 1px solid #e4e9f2;
-    border-radius: 14px;
-    padding: 18px 20px;
-    background: #ffffff;
-    transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
-}
-
-.flygit-item:hover,
-.flygit-item:focus-within {
-    border-color: #c5d6f2;
-    box-shadow: 0 18px 40px -32px rgba(30, 64, 175, 0.45);
-    transform: translateY(-1px);
-}
-
-.flygit-item:last-of-type {
-    margin-bottom: 0;
-}
-
-.flygit-item-summary {
-    cursor: pointer;
-    display: grid;
-    grid-template-columns: 1fr auto;
-    gap: 12px;
-    align-items: center;
-    list-style: none;
-}
-
-.flygit-item summary::-webkit-details-marker {
-    display: none;
-}
-
-.flygit-item-summary::after {
-    content: '\f347';
-    font-family: 'dashicons';
-    font-size: 18px;
-    line-height: 1;
-    color: #5b6b7d;
-    transition: transform 0.2s ease, color 0.2s ease;
-}
-
-.flygit-item[open] .flygit-item-summary::after {
-    transform: rotate(180deg);
-    color: #1f4e8c;
-}
-
-.flygit-item-title {
-    font-weight: 600;
-    font-size: 17px;
-    color: #1d2327;
-}
-
-.flygit-item-meta {
-    display: flex;
-    gap: 12px;
-    font-size: 13px;
-    color: #4b5563;
-    align-items: center;
-    flex-wrap: wrap;
-}
-
-.flygit-status {
-    padding: 2px 8px;
-    border-radius: 999px;
-    font-size: 11px;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    font-weight: 600;
-}
-
-.flygit-status-active {
-    background: #e3f8d2;
-    color: #1f6c36;
-}
-
-.flygit-status-inactive {
-    background: #fde4e4;
-    color: #8c1d1d;
-}
-
-.flygit-item-body {
-    margin-top: 16px;
-    display: grid;
-    gap: 16px;
-    border-top: 1px solid #edf2f8;
-    padding-top: 16px;
-}
-
-.flygit-description {
+.flygit-side-description {
     margin: 0;
-    color: #1d2327;
+    color: #475569;
     line-height: 1.6;
 }
 
-.flygit-meta {
+.flygit-collection {
+    display: grid;
+    gap: 16px;
+}
+
+.flygit-collection-item {
+    border: 1px solid #e7ecf5;
+    border-radius: 20px;
+    background: #fbfcff;
+    box-shadow: 0 24px 60px -50px rgba(30, 64, 175, 0.35);
+    transition: border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.flygit-collection-item.is-active {
+    border-color: #c7d2fe;
+}
+
+.flygit-collection-item[open] {
+    border-color: #a5b4fc;
+    box-shadow: 0 30px 70px -50px rgba(79, 70, 229, 0.38);
+}
+
+.flygit-collection-summary {
+    list-style: none;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 16px;
+    align-items: center;
+    padding: 22px 24px;
+    cursor: pointer;
+    position: relative;
+}
+
+.flygit-collection-summary::-webkit-details-marker {
+    display: none;
+}
+
+.flygit-collection-summary::after {
+    content: '\f347';
+    font-family: 'dashicons';
+    font-size: 18px;
+    color: #64748b;
+    transition: transform 0.2s ease, color 0.2s ease;
+}
+
+.flygit-collection-item[open] > .flygit-collection-summary::after {
+    transform: rotate(180deg);
+    color: #4f46e5;
+}
+
+.flygit-collection-summary-main {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-width: 0;
+}
+
+.flygit-collection-name {
+    font-size: 17px;
+    font-weight: 600;
+    color: #111827;
+}
+
+.flygit-collection-tags {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+}
+
+.flygit-chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 3px 10px;
+    border-radius: 999px;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+
+.flygit-chip.is-success {
+    background: #dcfce7;
+    color: #047857;
+}
+
+.flygit-chip.is-neutral {
+    background: #f1f5f9;
+    color: #475569;
+}
+
+.flygit-collection-summary-meta {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+    color: #64748b;
+    font-size: 13px;
+}
+
+.flygit-collection-body {
+    padding: 0 24px 24px;
+    display: grid;
+    gap: 18px;
+    border-top: 1px solid #e7ecf5;
+    background: #ffffff;
+}
+
+.flygit-collection-description {
+    margin: 16px 0 0;
+    color: #1f2937;
+    line-height: 1.6;
+}
+
+.flygit-meta-list {
     margin: 0;
     padding: 0;
     list-style: none;
     display: grid;
-    gap: 6px;
+    gap: 10px;
     color: #4b5563;
     font-size: 13px;
 }
 
-.flygit-meta li {
-    margin: 0;
+.flygit-sublist {
+    margin: 8px 0 0;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    gap: 6px;
 }
 
-.flygit-actions {
+.flygit-sublist li {
     display: flex;
-    gap: 10px;
-    flex-wrap: wrap;
+    gap: 8px;
     align-items: center;
+    flex-wrap: wrap;
+}
+
+.flygit-sublist code {
+    background: #eef2ff;
+    padding: 4px 6px;
+    border-radius: 6px;
+    font-size: 12px;
+}
+
+.flygit-action-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-items: center;
+}
+
+.flygit-action-button {
+    border-radius: 12px !important;
+    padding: 8px 14px !important;
+    font-weight: 600 !important;
+    line-height: 1.3;
+}
+
+.flygit-action-link a {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    color: #1d4ed8;
+    border-radius: 10px;
+    padding: 6px 10px;
+    font-size: 12px;
+    font-weight: 600;
 }
 
 .flygit-inline-form {
     display: inline-flex;
     align-items: center;
-    margin: 0;
 }
 
 .flygit-inline-form button {
     margin: 0;
 }
 
-.flygit-action-link {
-    display: inline-flex;
-    align-items: center;
+.flygit-button-danger {
+    background: #ef4444 !important;
+    border-color: #ef4444 !important;
+    color: #ffffff !important;
 }
 
-.flygit-action-link a {
-    margin: 0;
+.flygit-button-danger:hover,
+.flygit-button-danger:focus {
+    background: #dc2626 !important;
+    border-color: #dc2626 !important;
+    color: #ffffff !important;
 }
 
-.flygit-actions .button.disabled {
-    pointer-events: none;
-    opacity: 0.65;
-}
-
-.flygit-section-footer {
-    border-top: 1px solid #e3e6ed;
-    padding: 24px;
+.flygit-collection-settings {
+    border: 1px solid #e0e7ff;
+    background: linear-gradient(180deg, #f5f7ff 0%, #eef2ff 100%);
+    border-radius: 18px;
+    padding: 18px;
     display: grid;
     gap: 16px;
-    background: linear-gradient(180deg, #f9fbff 0%, #f1f5fb 100%);
 }
 
-.flygit-section-footer h3 {
+.flygit-collection-settings h4 {
     margin: 0;
-    font-size: 18px;
-    color: #1d2327;
+    font-size: 15px;
+    font-weight: 600;
+    color: #1f2937;
+}
+
+.flygit-webhook-block {
+    display: grid;
+    gap: 10px;
+}
+
+.flygit-webhook-label {
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-weight: 700;
+    color: #4338ca;
+}
+
+.flygit-webhook-endpoint {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    background: #f8fafc;
+    border: 1px solid #dbe4ff;
+    border-radius: 12px;
+    padding: 10px 12px;
+}
+
+.flygit-webhook-endpoint code {
+    flex: 1;
+    font-size: 12px;
+    word-break: break-all;
+}
+
+.flygit-webhook-endpoint .button {
+    border-radius: 10px;
 }
 
 .flygit-form {
@@ -396,79 +564,56 @@
 }
 
 .flygit-form label {
-    display: flex;
-    flex-direction: column;
+    display: grid;
     gap: 6px;
     font-weight: 600;
-    color: #1d2327;
+    color: #1f2937;
 }
 
 .flygit-form input,
 .flygit-form textarea {
     width: 100%;
-    border-radius: 10px;
-    border: 1px solid #cbd5e1;
+    border-radius: 12px;
+    border: 1px solid #dbe2f3;
     background: #ffffff;
-    padding: 10px 12px;
+    padding: 11px 14px;
     transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .flygit-form input:focus,
 .flygit-form textarea:focus {
-    border-color: #2271b1;
-    box-shadow: 0 0 0 3px rgba(34, 113, 177, 0.25);
+    border-color: #6366f1;
+    box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.25);
     outline: none;
 }
 
-.flygit-installation-settings {
-    border: 1px solid #dce7fb;
-    background: #f3f7ff;
-    border-radius: 12px;
-    padding: 16px;
-    display: grid;
-    gap: 14px;
+.flygit-submit-button {
+    border-radius: 14px !important;
+    padding: 12px 18px !important;
+    font-size: 14px !important;
+    font-weight: 600 !important;
 }
 
-.flygit-installation-settings h4 {
+.flygit-section-description {
     margin: 0;
-    font-size: 16px;
-    color: #1d2327;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+    color: #475569;
+    font-size: 14px;
+    line-height: 1.6;
 }
 
-.flygit-installation-webhook {
-    display: grid;
-    gap: 10px;
+.flygit-section-description code {
+    background: #eef2ff;
+    padding: 4px 8px;
+    border-radius: 8px;
 }
 
-.flygit-installation-subtitle {
-    font-weight: 600;
+.flygit-snippets-path-alt {
+    color: #64748b;
     font-size: 13px;
-    color: #1f365f;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-}
-
-.flygit-button-danger {
-    background: #c62828;
-    border-color: #c62828;
-    color: #ffffff;
-}
-
-.flygit-button-danger:hover,
-.flygit-button-danger:focus {
-    background: #a82222;
-    border-color: #a82222;
-    color: #ffffff;
-}
-
-.flygit-snippets-body {
-    padding: 24px;
-    display: grid;
-    gap: 24px;
-}
-
-.flygit-snippet-form .description {
-    margin: 0;
 }
 
 .flygit-snippets-list {
@@ -476,219 +621,139 @@
     gap: 16px;
 }
 
+.flygit-snippets-list h3 {
+    margin: 0;
+    font-size: 18px;
+    font-weight: 600;
+    color: #111827;
+}
+
 .flygit-snippet-list {
     list-style: none;
     margin: 0;
     padding: 0;
     display: grid;
-    gap: 12px;
+    gap: 14px;
 }
 
 .flygit-snippet-item {
-    border: 1px solid #e1e6ef;
-    border-radius: 12px;
-    background: #f6f9ff;
+    border: 1px solid #e6ecfb;
+    border-radius: 16px;
+    background: #f8fbff;
     padding: 16px 18px;
     display: grid;
-    gap: 8px;
+    gap: 10px;
 }
 
 .flygit-snippet-title {
     font-weight: 600;
     font-size: 16px;
-    color: #1d2327;
+    color: #1f2937;
 }
 
 .flygit-snippet-meta {
     display: flex;
     flex-wrap: wrap;
     gap: 12px;
-    font-size: 13px;
-    color: #4b5563;
+    font-size: 12px;
+    color: #475569;
 }
 
 .flygit-snippet-meta span {
     display: inline-flex;
     gap: 4px;
+    align-items: center;
 }
 
 .flygit-snippet-description {
     margin: 0;
-    color: #1d2327;
+    color: #1f2937;
     line-height: 1.6;
-}
-
-.flygit-snippets-path-alt {
-    margin-left: 6px;
-    color: #50575e;
-    font-size: 12px;
-}
-
-.flygit-webhook-content {
-    padding: 24px;
-    display: grid;
-    gap: 24px;
-}
-
-.flygit-webhook-grid {
-    display: grid;
-    gap: 20px;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-}
-
-.flygit-webhook-list {
-    display: grid;
-    gap: 16px;
-}
-
-.flygit-webhook-card {
-    background: #ffffff;
-    border: 1px solid #dcdcde;
-    border-radius: 16px;
-    padding: 18px;
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-}
-
-.flygit-webhook-card-header {
-    margin: 0;
-}
-
-.flygit-webhook-title {
-    margin: 0;
-    font-size: 16px;
-    font-weight: 600;
-    color: #1d2327;
-}
-
-.flygit-webhook-meta {
-    margin: 6px 0 0;
-    display: flex;
-    gap: 8px;
-    align-items: center;
-    font-size: 13px;
-    color: #50575e;
-}
-
-.flygit-webhook-body {
-    display: grid;
-    gap: 12px;
-}
-
-.flygit-webhook-endpoint {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    background: #f1f5f9;
-    border: 1px solid #d4dde7;
-    border-radius: 8px;
-    padding: 10px 12px;
-}
-
-.flygit-webhook-endpoint code {
-    flex: 1;
-    word-break: break-all;
-}
-
-.flygit-section pre {
-    background: #f6f9ff;
-    border: 1px solid #e1e6ef;
-    padding: 12px;
-    border-radius: 6px;
-    overflow: auto;
-    margin: 0;
 }
 
 .flygit-empty-state {
     display: inline-flex;
     align-items: center;
-    gap: 8px;
-    background: #f6f9ff;
-    border: 1px dashed #c7d4ef;
-    color: #415066;
+    gap: 10px;
+    background: #f8fafc;
+    border: 1px dashed #c7d2fe;
+    color: #4f46e5;
     padding: 12px 16px;
-    border-radius: 12px;
-    font-size: 14px;
+    border-radius: 16px;
+    font-size: 13px;
 }
 
 .flygit-empty-state .dashicons {
     font-size: 18px;
-    color: #1f4e8c;
 }
 
-.flygit-webhook-endpoint .button,
-.flygit-actions .button,
-.flygit-form .button {
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
+.flygit-dashboard a.flygit-cta,
+.flygit-dashboard .button,
+.flygit-dashboard .flygit-action-link a {
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease, color 0.2s ease;
 }
 
-.flygit-webhook-endpoint .button:hover,
-.flygit-webhook-endpoint .button:focus,
-.flygit-actions .button:hover,
-.flygit-actions .button:focus,
-.flygit-form .button:hover,
-.flygit-form .button:focus {
+.flygit-dashboard a.flygit-cta:hover,
+.flygit-dashboard a.flygit-cta:focus,
+.flygit-dashboard .button:hover,
+.flygit-dashboard .button:focus,
+.flygit-dashboard .flygit-action-link a:hover,
+.flygit-dashboard .flygit-action-link a:focus {
     transform: translateY(-1px);
-    box-shadow: 0 10px 24px -18px rgba(15, 23, 42, 0.5);
+    box-shadow: 0 18px 40px -28px rgba(15, 23, 42, 0.4);
 }
 
-.flygit-webhook-endpoint .button:focus-visible,
-.flygit-actions .button:focus-visible,
-.flygit-form .button:focus-visible {
-    outline: 2px solid #2271b1;
-    outline-offset: 2px;
-}
-
-.flygit-webhook-endpoint .button.disabled,
-.flygit-actions .button.disabled {
-    box-shadow: none;
+.flygit-dashboard .button.disabled {
     transform: none;
+    box-shadow: none;
 }
 
-@media (min-width: 782px) {
-    .flygit-form > label {
-        max-width: 420px;
+@media (min-width: 1100px) {
+    .flygit-card-body--split {
+        grid-template-columns: minmax(0, 1fr) 320px;
     }
 }
 
-@media (max-width: 900px) {
-    .flygit-hero {
+@media (max-width: 960px) {
+    .flygit-dashboard-header {
+        padding: 36px;
+    }
+
+    .flygit-header-inner {
         flex-direction: column;
-        align-items: flex-start;
-        padding: 28px;
     }
 
-    .flygit-hero-actions {
-        justify-content: flex-start;
+    .flygit-card-body--split {
+        grid-template-columns: minmax(0, 1fr);
     }
 }
 
 @media (max-width: 782px) {
-    .flygit-hero-body h1 {
-        font-size: 24px;
+    .flygit-header-text h1 {
+        font-size: 28px;
     }
 
-    .flygit-stat-value {
-        font-size: 24px;
+    .flygit-card-header {
+        padding: 28px 24px 0;
     }
 
-    .flygit-item-summary {
-        grid-template-columns: 1fr;
+    .flygit-card-body {
+        padding: 28px 24px 28px;
     }
 
-    .flygit-item-summary::after {
-        justify-self: end;
+    .flygit-collection-summary {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .flygit-collection-summary::after {
+        justify-self: flex-end;
     }
 }
 
 @media (prefers-reduced-motion: reduce) {
-    .flygit-hero-button,
-    .flygit-stat-card,
-    .flygit-item,
-    .flygit-webhook-endpoint .button,
-    .flygit-actions .button,
-    .flygit-form .button {
+    .flygit-dashboard a.flygit-cta,
+    .flygit-dashboard .button,
+    .flygit-dashboard .flygit-action-link a {
         transition: none;
     }
 }

--- a/includes/views/dashboard.php
+++ b/includes/views/dashboard.php
@@ -12,609 +12,653 @@
 /** @var string $code_snippet_error */
 /** @var string $snippet_storage_path */
 /** @var string $snippet_storage_display */
-
 ?>
 <div class="wrap flygit-dashboard">
     <?php
-    $theme_total            = isset( $installed_count['themes'] ) ? (int) $installed_count['themes'] : ( is_array( $themes ) ? count( $themes ) : 0 );
-    $plugin_total           = isset( $installed_count['plugins'] ) ? (int) $installed_count['plugins'] : ( is_array( $plugins ) ? count( $plugins ) : 0 );
-    $snippet_total          = isset( $installed_count['snippets'] ) ? (int) $installed_count['snippets'] : ( isset( $snippet_installations ) && is_array( $snippet_installations ) ? count( $snippet_installations ) : 0 );
-    $active_plugin_count    = is_array( $active_plugins ) ? count( $active_plugins ) : 0;
-    $current_theme_name     = ( $current_theme instanceof WP_Theme ) ? $current_theme->get( 'Name' ) : '';
-    $stored_snippet_count   = is_array( $code_snippets ) ? count( $code_snippets ) : 0;
+    $theme_total          = isset( $installed_count['themes'] ) ? (int) $installed_count['themes'] : ( is_array( $themes ) ? count( $themes ) : 0 );
+    $plugin_total         = isset( $installed_count['plugins'] ) ? (int) $installed_count['plugins'] : ( is_array( $plugins ) ? count( $plugins ) : 0 );
+    $snippet_total        = isset( $installed_count['snippets'] ) ? (int) $installed_count['snippets'] : ( isset( $snippet_installations ) && is_array( $snippet_installations ) ? count( $snippet_installations ) : 0 );
+    $active_plugin_count  = is_array( $active_plugins ) ? count( $active_plugins ) : 0;
+    $current_theme_name   = ( $current_theme instanceof WP_Theme ) ? $current_theme->get( 'Name' ) : '';
+    $stored_snippet_count = is_array( $code_snippets ) ? count( $code_snippets ) : 0;
     ?>
 
-    <header class="flygit-hero">
-        <div class="flygit-hero-body">
-            <h1><?php esc_html_e( 'FlyGit Dashboard', 'flygit' ); ?></h1>
-            <p>
-                <?php esc_html_e( 'Manage Git-powered deployments for your WordPress themes, plugins, and snippets in one place.', 'flygit' ); ?>
-            </p>
-            <?php if ( ! empty( $current_theme_name ) ) : ?>
-                <span class="flygit-hero-meta">
-                    <?php printf( esc_html__( 'Current theme: %s', 'flygit' ), esc_html( $current_theme_name ) ); ?>
-                </span>
-            <?php endif; ?>
+    <section class="flygit-dashboard-header" id="flygit-overview">
+        <div class="flygit-header-inner">
+            <div class="flygit-header-text">
+                <span class="flygit-pill"><?php esc_html_e( 'Deployment control', 'flygit' ); ?></span>
+                <h1><?php esc_html_e( 'FlyGit Dashboard', 'flygit' ); ?></h1>
+                <p>
+                    <?php esc_html_e( 'Keep every Git-powered deployment within easy reach. Track versions, pull updates, and import snippets from a calm, modern control centre.', 'flygit' ); ?>
+                </p>
+                <?php if ( ! empty( $current_theme_name ) ) : ?>
+                    <div class="flygit-header-meta">
+                        <span class="dashicons dashicons-admin-appearance" aria-hidden="true"></span>
+                        <span><?php printf( esc_html__( 'Active theme: %s', 'flygit' ), esc_html( $current_theme_name ) ); ?></span>
+                    </div>
+                <?php endif; ?>
+
+                <div class="flygit-header-actions" aria-label="<?php esc_attr_e( 'Quick actions', 'flygit' ); ?>">
+                    <a class="flygit-cta is-primary" href="#flygit-install-theme">
+                        <span class="dashicons dashicons-admin-appearance" aria-hidden="true"></span>
+                        <span><?php esc_html_e( 'Install Theme', 'flygit' ); ?></span>
+                    </a>
+                    <a class="flygit-cta" href="#flygit-install-plugin">
+                        <span class="dashicons dashicons-admin-plugins" aria-hidden="true"></span>
+                        <span><?php esc_html_e( 'Install Plugin', 'flygit' ); ?></span>
+                    </a>
+                    <a class="flygit-cta" href="#flygit-import-snippets">
+                        <span class="dashicons dashicons-media-code" aria-hidden="true"></span>
+                        <span><?php esc_html_e( 'Import Snippets', 'flygit' ); ?></span>
+                    </a>
+                </div>
+            </div>
+
+            <div class="flygit-header-summary" role="list">
+                <div class="flygit-header-stat" role="listitem">
+                    <span class="flygit-header-stat-label"><?php esc_html_e( 'Themes managed', 'flygit' ); ?></span>
+                    <span class="flygit-header-stat-value"><?php echo esc_html( number_format_i18n( $theme_total ) ); ?></span>
+                    <?php if ( ! empty( $current_theme_name ) ) : ?>
+                        <span class="flygit-header-stat-sub"><?php printf( esc_html__( 'Active: %s', 'flygit' ), esc_html( $current_theme_name ) ); ?></span>
+                    <?php else : ?>
+                        <span class="flygit-header-stat-sub"><?php esc_html_e( 'No active theme detected.', 'flygit' ); ?></span>
+                    <?php endif; ?>
+                </div>
+                <div class="flygit-header-stat" role="listitem">
+                    <span class="flygit-header-stat-label"><?php esc_html_e( 'Plugins managed', 'flygit' ); ?></span>
+                    <span class="flygit-header-stat-value"><?php echo esc_html( number_format_i18n( $plugin_total ) ); ?></span>
+                    <span class="flygit-header-stat-sub"><?php printf( esc_html__( '%d active plugins', 'flygit' ), (int) $active_plugin_count ); ?></span>
+                </div>
+                <div class="flygit-header-stat" role="listitem">
+                    <span class="flygit-header-stat-label"><?php esc_html_e( 'Snippet repositories', 'flygit' ); ?></span>
+                    <span class="flygit-header-stat-value"><?php echo esc_html( number_format_i18n( $snippet_total ) ); ?></span>
+                    <span class="flygit-header-stat-sub"><?php printf( esc_html__( '%d stored snippets', 'flygit' ), (int) $stored_snippet_count ); ?></span>
+                </div>
+            </div>
         </div>
-        <div class="flygit-hero-actions" aria-label="<?php esc_attr_e( 'Quick actions', 'flygit' ); ?>">
-            <a class="button button-primary flygit-hero-button" href="#flygit-install-theme">
-                <span class="dashicons dashicons-admin-appearance" aria-hidden="true"></span>
-                <span><?php esc_html_e( 'Install Theme', 'flygit' ); ?></span>
-            </a>
-            <a class="button flygit-hero-button" href="#flygit-install-plugin">
-                <span class="dashicons dashicons-admin-plugins" aria-hidden="true"></span>
-                <span><?php esc_html_e( 'Install Plugin', 'flygit' ); ?></span>
-            </a>
-            <a class="button flygit-hero-button" href="#flygit-import-snippets">
-                <span class="dashicons dashicons-media-code" aria-hidden="true"></span>
-                <span><?php esc_html_e( 'Import Snippets', 'flygit' ); ?></span>
-            </a>
-        </div>
-    </header>
+    </section>
 
     <?php if ( ! empty( $status ) && ! empty( $message ) ) : ?>
-        <?php
-        $class = ( 'success' === $status ) ? 'notice-success' : 'notice-error';
-        ?>
-        <div class="notice <?php echo esc_attr( $class ); ?> is-dismissible">
-            <p><?php echo esc_html( $message ); ?></p>
+        <?php $class = ( 'success' === $status ) ? 'flygit-alert-success' : 'flygit-alert-error'; ?>
+        <div class="flygit-alert <?php echo esc_attr( $class ); ?>">
+            <span class="flygit-alert-icon dashicons <?php echo 'success' === $status ? 'dashicons-yes-alt' : 'dashicons-warning'; ?>" aria-hidden="true"></span>
+            <span class="flygit-alert-message"><?php echo esc_html( $message ); ?></span>
         </div>
     <?php endif; ?>
 
-    <div class="flygit-stats-grid" role="list">
-        <div class="flygit-stat-card" role="listitem">
-            <span class="flygit-stat-icon dashicons dashicons-admin-appearance" aria-hidden="true"></span>
-            <div class="flygit-stat-content">
-                <span class="flygit-stat-label"><?php esc_html_e( 'Themes managed', 'flygit' ); ?></span>
-                <span class="flygit-stat-value"><?php echo esc_html( number_format_i18n( $theme_total ) ); ?></span>
-                <?php if ( ! empty( $current_theme_name ) ) : ?>
-                    <span class="flygit-stat-sub"><?php printf( esc_html__( 'Active theme: %s', 'flygit' ), esc_html( $current_theme_name ) ); ?></span>
-                <?php else : ?>
-                    <span class="flygit-stat-sub"><?php esc_html_e( 'No active theme detected.', 'flygit' ); ?></span>
-                <?php endif; ?>
-            </div>
-        </div>
-        <div class="flygit-stat-card" role="listitem">
-            <span class="flygit-stat-icon dashicons dashicons-admin-plugins" aria-hidden="true"></span>
-            <div class="flygit-stat-content">
-                <span class="flygit-stat-label"><?php esc_html_e( 'Plugins managed', 'flygit' ); ?></span>
-                <span class="flygit-stat-value"><?php echo esc_html( number_format_i18n( $plugin_total ) ); ?></span>
-                <span class="flygit-stat-sub"><?php printf( esc_html__( '%d active plugins', 'flygit' ), (int) $active_plugin_count ); ?></span>
-            </div>
-        </div>
-        <div class="flygit-stat-card" role="listitem">
-            <span class="flygit-stat-icon dashicons dashicons-media-code" aria-hidden="true"></span>
-            <div class="flygit-stat-content">
-                <span class="flygit-stat-label"><?php esc_html_e( 'Snippet repositories', 'flygit' ); ?></span>
-                <span class="flygit-stat-value"><?php echo esc_html( number_format_i18n( $snippet_total ) ); ?></span>
-                <span class="flygit-stat-sub"><?php printf( esc_html__( '%d stored snippets', 'flygit' ), (int) $stored_snippet_count ); ?></span>
-            </div>
-        </div>
-    </div>
+    <div class="flygit-dashboard-content">
+        <div class="flygit-columns">
+            <section class="flygit-card" id="flygit-themes">
+                <div class="flygit-card-header">
+                    <div>
+                        <span class="flygit-eyebrow"><?php esc_html_e( 'Themes', 'flygit' ); ?></span>
+                        <h2><?php esc_html_e( 'Installed Themes', 'flygit' ); ?></h2>
+                    </div>
+                    <span class="flygit-counter"><?php echo esc_html( number_format_i18n( $theme_total ) ); ?></span>
+                </div>
 
-    <div class="flygit-columns">
-        <div class="flygit-column">
-            <section class="flygit-section">
-                <header class="flygit-section-header">
-                    <h2>
-                        <?php esc_html_e( 'Installed Themes', 'flygit' ); ?>
-                        <span class="flygit-badge"><?php echo esc_html( $installed_count['themes'] ); ?></span>
-                    </h2>
-                </header>
-                <div class="flygit-list">
-                    <?php if ( ! empty( $themes ) ) : ?>
-                        <?php foreach ( $themes as $stylesheet => $theme ) : ?>
-                        <?php
-                        $theme_slug         = $theme->get_stylesheet();
-                        $theme_installation = isset( $theme_installations_map[ $theme_slug ] ) ? $theme_installations_map[ $theme_slug ] : null;
-                        $is_active          = ( $current_theme->get_stylesheet() === $theme_slug );
-                        $theme_name         = $theme->get( 'Name' );
-                        $theme_description  = $theme->get( 'Description' );
-                        $activate_url       = wp_nonce_url(
-                            admin_url( 'themes.php?action=activate&stylesheet=' . $theme_slug ),
-                            'switch-theme_' . $theme_slug
-                        );
-                        $customize_url = admin_url( 'customize.php?theme=' . $theme_slug );
-                        $details_url   = admin_url( 'theme-install.php?tab=theme-information&theme=' . $theme_slug );
-                        $uninstall_label = $theme_name ? $theme_name : $theme_slug;
-                        $uninstall_message = sprintf( esc_html__( 'Are you sure you want to uninstall the theme "%s"?', 'flygit' ), $uninstall_label );
-                        ?>
-                        <details class="flygit-item" <?php echo $is_active ? 'open' : ''; ?>>
-                            <summary class="flygit-item-summary">
-                                <span class="flygit-item-title"><?php echo esc_html( $theme_name ); ?></span>
-                                <span class="flygit-item-meta">
-                                    <?php if ( $is_active ) : ?>
-                                        <span class="flygit-status flygit-status-active"><?php esc_html_e( 'Active', 'flygit' ); ?></span>
-                                    <?php else : ?>
-                                        <span class="flygit-status flygit-status-inactive"><?php esc_html_e( 'Inactive', 'flygit' ); ?></span>
-                                    <?php endif; ?>
-                                    <span><?php printf( esc_html__( 'Version %s', 'flygit' ), esc_html( $theme->get( 'Version' ) ) ); ?></span>
-                                </span>
-                            </summary>
-                            <div class="flygit-item-body">
-                                <?php if ( $theme_description ) : ?>
-                                    <p class="flygit-description"><?php echo esc_html( $theme_description ); ?></p>
-                                <?php endif; ?>
-
-                                <ul class="flygit-meta">
-                                    <li><strong><?php esc_html_e( 'Author:', 'flygit' ); ?></strong> <?php echo wp_kses_post( $theme->get( 'Author' ) ); ?></li>
-                                    <li><strong><?php esc_html_e( 'Template:', 'flygit' ); ?></strong> <?php echo esc_html( $theme->get_template() ); ?></li>
+                <div class="flygit-card-body flygit-card-body--split">
+                    <div class="flygit-card-main">
+                        <div class="flygit-collection" role="list">
+                            <?php if ( ! empty( $themes ) ) : ?>
+                                <?php foreach ( $themes as $stylesheet => $theme ) : ?>
                                     <?php
-                                    $theme_tags = $theme->get( 'Tags' );
-                                    if ( ! empty( $theme_tags ) ) :
-                                        if ( is_array( $theme_tags ) ) {
-                                            $theme_tags = implode( ', ', $theme_tags );
-                                        }
+                                    $theme_slug         = $theme->get_stylesheet();
+                                    $theme_installation = isset( $theme_installations_map[ $theme_slug ] ) ? $theme_installations_map[ $theme_slug ] : null;
+                                    $is_active          = ( $current_theme instanceof WP_Theme ) && ( $current_theme->get_stylesheet() === $theme_slug );
+                                    $theme_name         = $theme->get( 'Name' );
+                                    $theme_description  = $theme->get( 'Description' );
+                                    $activate_url       = wp_nonce_url(
+                                        admin_url( 'themes.php?action=activate&stylesheet=' . $theme_slug ),
+                                        'switch-theme_' . $theme_slug
+                                    );
+                                    $customize_url       = admin_url( 'customize.php?theme=' . $theme_slug );
+                                    $details_url         = admin_url( 'theme-install.php?tab=theme-information&theme=' . $theme_slug );
+                                    $uninstall_label     = $theme_name ? $theme_name : $theme_slug;
+                                    $uninstall_message   = sprintf( esc_html__( 'Are you sure you want to uninstall the theme "%s"?', 'flygit' ), $uninstall_label );
                                     ?>
-                                        <li><strong><?php esc_html_e( 'Tags:', 'flygit' ); ?></strong> <?php echo esc_html( $theme_tags ); ?></li>
-                                    <?php endif; ?>
-                                </ul>
+                                    <details class="flygit-collection-item <?php echo $is_active ? 'is-active' : ''; ?>" <?php echo $is_active ? 'open' : ''; ?> role="listitem">
+                                        <summary class="flygit-collection-summary">
+                                            <div class="flygit-collection-summary-main">
+                                                <span class="flygit-collection-name"><?php echo esc_html( $theme_name ); ?></span>
+                                                <div class="flygit-collection-tags">
+                                                    <?php if ( $is_active ) : ?>
+                                                        <span class="flygit-chip is-success"><?php esc_html_e( 'Active', 'flygit' ); ?></span>
+                                                    <?php else : ?>
+                                                        <span class="flygit-chip is-neutral"><?php esc_html_e( 'Inactive', 'flygit' ); ?></span>
+                                                    <?php endif; ?>
+                                                </div>
+                                            </div>
+                                            <div class="flygit-collection-summary-meta">
+                                                <span><?php printf( esc_html__( 'Version %s', 'flygit' ), esc_html( $theme->get( 'Version' ) ) ); ?></span>
+                                            </div>
+                                        </summary>
+                                        <div class="flygit-collection-body">
+                                            <?php if ( $theme_description ) : ?>
+                                                <p class="flygit-collection-description"><?php echo esc_html( $theme_description ); ?></p>
+                                            <?php endif; ?>
 
-                                <div class="flygit-actions">
-                                    <?php if ( ! $is_active ) : ?>
-                                        <a class="button button-primary" href="<?php echo esc_url( $activate_url ); ?>"><?php esc_html_e( 'Activate', 'flygit' ); ?></a>
-                                    <?php else : ?>
-                                        <span class="button disabled"><?php esc_html_e( 'Active', 'flygit' ); ?></span>
-                                    <?php endif; ?>
+                                            <ul class="flygit-meta-list">
+                                                <li><strong><?php esc_html_e( 'Author:', 'flygit' ); ?></strong> <?php echo wp_kses_post( $theme->get( 'Author' ) ); ?></li>
+                                                <li><strong><?php esc_html_e( 'Template:', 'flygit' ); ?></strong> <?php echo esc_html( $theme->get_template() ); ?></li>
+                                                <?php
+                                                $theme_tags = $theme->get( 'Tags' );
+                                                if ( ! empty( $theme_tags ) ) {
+                                                    if ( is_array( $theme_tags ) ) {
+                                                        $theme_tags = implode( ', ', $theme_tags );
+                                                    }
+                                                    ?>
+                                                    <li><strong><?php esc_html_e( 'Tags:', 'flygit' ); ?></strong> <?php echo esc_html( $theme_tags ); ?></li>
+                                                    <?php
+                                                }
+                                                ?>
+                                            </ul>
 
-                                    <a class="button" href="<?php echo esc_url( $customize_url ); ?>"><?php esc_html_e( 'Customize', 'flygit' ); ?></a>
-                                    <a class="button" href="<?php echo esc_url( $details_url ); ?>"><?php esc_html_e( 'Details', 'flygit' ); ?></a>
-                                    <?php if ( $theme_installation ) : ?>
-                                        <?php if ( $theme_installation['is_active'] ) : ?>
-                                            <span class="button disabled" title="<?php esc_attr_e( 'Active themes cannot be uninstalled.', 'flygit' ); ?>"><?php esc_html_e( 'Uninstall', 'flygit' ); ?></span>
-                                        <?php else : ?>
-                                            <form class="flygit-inline-form" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" onsubmit="return confirm('<?php echo esc_js( $uninstall_message ); ?>');">
+                                            <div class="flygit-action-row">
+                                                <?php if ( ! $is_active ) : ?>
+                                                    <a class="button button-primary flygit-action-button" href="<?php echo esc_url( $activate_url ); ?>">
+                                                        <?php esc_html_e( 'Activate', 'flygit' ); ?>
+                                                    </a>
+                                                <?php else : ?>
+                                                    <span class="button disabled flygit-action-button"><?php esc_html_e( 'Active', 'flygit' ); ?></span>
+                                                <?php endif; ?>
+                                                <a class="button flygit-action-button" href="<?php echo esc_url( $customize_url ); ?>">
+                                                    <?php esc_html_e( 'Customize', 'flygit' ); ?>
+                                                </a>
+                                                <a class="button flygit-action-button" href="<?php echo esc_url( $details_url ); ?>">
+                                                    <?php esc_html_e( 'Details', 'flygit' ); ?>
+                                                </a>
+                                                <?php if ( $theme_installation ) : ?>
+                                                    <?php if ( $theme_installation['is_active'] ) : ?>
+                                                        <span class="button disabled flygit-action-button" title="<?php esc_attr_e( 'Active themes cannot be uninstalled.', 'flygit' ); ?>">
+                                                            <?php esc_html_e( 'Uninstall', 'flygit' ); ?>
+                                                        </span>
+                                                    <?php else : ?>
+                                                        <form class="flygit-inline-form" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" onsubmit="return confirm('<?php echo esc_js( $uninstall_message ); ?>');">
+                                                            <?php wp_nonce_field( 'flygit_uninstall' ); ?>
+                                                            <input type="hidden" name="action" value="flygit_uninstall" />
+                                                            <input type="hidden" name="installation_id" value="<?php echo esc_attr( $theme_installation['id'] ); ?>" />
+                                                            <button type="submit" class="button flygit-button-danger flygit-action-button"><?php esc_html_e( 'Uninstall', 'flygit' ); ?></button>
+                                                        </form>
+                                                    <?php endif; ?>
+                                                <?php endif; ?>
+                                            </div>
+
+                                            <?php if ( $theme_installation ) : ?>
+                                                <div class="flygit-collection-settings">
+                                                    <h4><?php esc_html_e( 'FlyGit Settings', 'flygit' ); ?></h4>
+
+                                                    <?php if ( ! empty( $theme_installation['repository_url'] ) || ! empty( $theme_installation['branch'] ) ) : ?>
+                                                        <ul class="flygit-meta-list">
+                                                            <?php if ( ! empty( $theme_installation['repository_url'] ) ) : ?>
+                                                                <li><strong><?php esc_html_e( 'Repository:', 'flygit' ); ?></strong> <a href="<?php echo esc_url( $theme_installation['repository_url'] ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $theme_installation['repository_url'] ); ?></a></li>
+                                                            <?php endif; ?>
+                                                            <?php if ( ! empty( $theme_installation['branch'] ) ) : ?>
+                                                                <li><strong><?php esc_html_e( 'Branch:', 'flygit' ); ?></strong> <?php echo esc_html( $theme_installation['branch'] ); ?></li>
+                                                            <?php endif; ?>
+                                                        </ul>
+                                                    <?php endif; ?>
+
+                                                    <?php $webhook_element_id = 'flygit-webhook-url-' . sanitize_html_class( $theme_installation['id'] ); ?>
+                                                    <div class="flygit-webhook-block">
+                                                        <span class="flygit-webhook-label"><?php esc_html_e( 'Webhook Endpoint', 'flygit' ); ?></span>
+                                                        <div class="flygit-webhook-endpoint">
+                                                            <code id="<?php echo esc_attr( $webhook_element_id ); ?>"><?php echo esc_html( $theme_installation['webhook_url'] ); ?></code>
+                                                            <button type="button" class="button flygit-copy" data-target="<?php echo esc_attr( $webhook_element_id ); ?>"><?php esc_html_e( 'Copy', 'flygit' ); ?></button>
+                                                        </div>
+                                                        <p class="description"><?php esc_html_e( 'Send a POST request to this endpoint to pull the latest code for the installation.', 'flygit' ); ?></p>
+                                                    </div>
+
+                                                    <form class="flygit-form" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+                                                        <?php wp_nonce_field( 'flygit_webhook_settings' ); ?>
+                                                        <input type="hidden" name="action" value="flygit_save_webhook_settings" />
+                                                        <input type="hidden" name="installation_id" value="<?php echo esc_attr( $theme_installation['id'] ); ?>" />
+                                                        <label>
+                                                            <?php esc_html_e( 'Webhook Secret (optional)', 'flygit' ); ?>
+                                                            <input type="text" name="webhook_secret" value="<?php echo esc_attr( $theme_installation['webhook_secret'] ); ?>" placeholder="<?php esc_attr_e( 'Secret token to verify requests', 'flygit' ); ?>" />
+                                                        </label>
+                                                        <p class="description"><?php esc_html_e( 'When set, authenticate the webhook using the X-Flygit-Secret header, a "secret" payload field, GitHub\'s X-Hub-Signature headers or GitLab\'s X-Gitlab-Token header.', 'flygit' ); ?></p>
+                                                        <p class="description"><?php esc_html_e( 'Payloads can be sent as application/json (recommended) or application/x-www-form-urlencoded.', 'flygit' ); ?></p>
+                                                        <button type="submit" class="button button-primary"><?php esc_html_e( 'Save Webhook Settings', 'flygit' ); ?></button>
+                                                    </form>
+                                                </div>
+                                            <?php endif; ?>
+                                        </div>
+                                    </details>
+                                <?php endforeach; ?>
+                            <?php else : ?>
+                                <p class="flygit-empty-state">
+                                    <span class="dashicons dashicons-admin-appearance" aria-hidden="true"></span>
+                                    <?php esc_html_e( 'No themes installed with FlyGit yet.', 'flygit' ); ?>
+                                </p>
+                            <?php endif; ?>
+                        </div>
+                    </div>
+
+                    <div class="flygit-card-side" id="flygit-install-theme">
+                        <div class="flygit-side-card">
+                            <h3><?php esc_html_e( 'Install Theme', 'flygit' ); ?></h3>
+                            <p class="flygit-side-description"><?php esc_html_e( 'Deploy a theme directly from a Git repository. FlyGit will clone the code and keep it ready for updates.', 'flygit' ); ?></p>
+
+                            <form class="flygit-form" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+                                <?php wp_nonce_field( 'flygit_install' ); ?>
+                                <input type="hidden" name="action" value="flygit_install" />
+                                <input type="hidden" name="install_type" value="theme" />
+
+                                <label>
+                                    <?php esc_html_e( 'Repository URL', 'flygit' ); ?>
+                                    <input type="url" name="repository_url" placeholder="https://github.com/owner/repo" required />
+                                </label>
+
+                                <label>
+                                    <?php esc_html_e( 'Branch', 'flygit' ); ?>
+                                    <input type="text" name="branch" placeholder="main" />
+                                </label>
+
+                                <label>
+                                    <?php esc_html_e( 'Access Token (optional)', 'flygit' ); ?>
+                                    <input type="password" name="access_token" autocomplete="off" />
+                                </label>
+
+                                <button type="submit" class="button button-primary flygit-submit-button"><?php esc_html_e( 'Install Theme', 'flygit' ); ?></button>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <section class="flygit-card" id="flygit-plugins">
+                <div class="flygit-card-header">
+                    <div>
+                        <span class="flygit-eyebrow"><?php esc_html_e( 'Plugins', 'flygit' ); ?></span>
+                        <h2><?php esc_html_e( 'Installed Plugins', 'flygit' ); ?></h2>
+                    </div>
+                    <span class="flygit-counter"><?php echo esc_html( number_format_i18n( $plugin_total ) ); ?></span>
+                </div>
+
+                <div class="flygit-card-body flygit-card-body--split">
+                    <div class="flygit-card-main">
+                        <div class="flygit-collection" role="list">
+                            <?php if ( ! empty( $plugins ) ) : ?>
+                                <?php foreach ( $plugins as $plugin_file => $plugin_data ) : ?>
+                                    <?php
+                                    $plugin_slug         = dirname( $plugin_file );
+                                    $plugin_installation = ( '.' !== $plugin_slug && isset( $plugin_installations_map[ $plugin_slug ] ) ) ? $plugin_installations_map[ $plugin_slug ] : null;
+                                    $is_active           = is_array( $active_plugins ) && in_array( $plugin_file, $active_plugins, true );
+                                    $activate_url        = wp_nonce_url(
+                                        admin_url( 'plugins.php?action=activate&plugin=' . $plugin_file ),
+                                        'activate-plugin_' . $plugin_file
+                                    );
+                                    $deactivate_url = wp_nonce_url(
+                                        admin_url( 'plugins.php?action=deactivate&plugin=' . $plugin_file ),
+                                        'deactivate-plugin_' . $plugin_file
+                                    );
+                                    $plugin_actions = apply_filters( 'plugin_action_links_' . $plugin_file, array(), $plugin_file, $plugin_data, 'flygit' );
+                                    $plugin_actions = apply_filters( 'plugin_action_links', $plugin_actions, $plugin_file, $plugin_data, 'flygit' );
+                                    $plugin_uninstall_label   = ! empty( $plugin_data['Name'] ) ? $plugin_data['Name'] : $plugin_slug;
+                                    $plugin_uninstall_message = sprintf( esc_html__( 'Are you sure you want to uninstall the plugin "%s"?', 'flygit' ), $plugin_uninstall_label );
+                                    ?>
+                                    <details class="flygit-collection-item" role="listitem">
+                                        <summary class="flygit-collection-summary">
+                                            <div class="flygit-collection-summary-main">
+                                                <span class="flygit-collection-name"><?php echo esc_html( $plugin_data['Name'] ); ?></span>
+                                                <div class="flygit-collection-tags">
+                                                    <?php if ( $is_active ) : ?>
+                                                        <span class="flygit-chip is-success"><?php esc_html_e( 'Active', 'flygit' ); ?></span>
+                                                    <?php else : ?>
+                                                        <span class="flygit-chip is-neutral"><?php esc_html_e( 'Inactive', 'flygit' ); ?></span>
+                                                    <?php endif; ?>
+                                                </div>
+                                            </div>
+                                            <div class="flygit-collection-summary-meta">
+                                                <span><?php printf( esc_html__( 'Version %s', 'flygit' ), esc_html( $plugin_data['Version'] ) ); ?></span>
+                                            </div>
+                                        </summary>
+                                        <div class="flygit-collection-body">
+                                            <?php if ( ! empty( $plugin_data['Description'] ) ) : ?>
+                                                <p class="flygit-collection-description"><?php echo esc_html( $plugin_data['Description'] ); ?></p>
+                                            <?php endif; ?>
+
+                                            <ul class="flygit-meta-list">
+                                                <li><strong><?php esc_html_e( 'Author:', 'flygit' ); ?></strong> <?php echo wp_kses_post( $plugin_data['Author'] ); ?></li>
+                                                <?php if ( ! empty( $plugin_data['PluginURI'] ) ) : ?>
+                                                    <li><strong><?php esc_html_e( 'Website:', 'flygit' ); ?></strong> <a href="<?php echo esc_url( $plugin_data['PluginURI'] ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $plugin_data['PluginURI'] ); ?></a></li>
+                                                <?php endif; ?>
+                                                <li><strong><?php esc_html_e( 'Path:', 'flygit' ); ?></strong> <code><?php echo esc_html( $plugin_file ); ?></code></li>
+                                            </ul>
+
+                                            <div class="flygit-action-row">
+                                                <?php if ( $is_active ) : ?>
+                                                    <a class="button flygit-action-button" href="<?php echo esc_url( $deactivate_url ); ?>"><?php esc_html_e( 'Deactivate', 'flygit' ); ?></a>
+                                                <?php else : ?>
+                                                    <a class="button button-primary flygit-action-button" href="<?php echo esc_url( $activate_url ); ?>"><?php esc_html_e( 'Activate', 'flygit' ); ?></a>
+                                                <?php endif; ?>
+
+                                                <?php
+                                                if ( ! empty( $plugin_actions ) && is_array( $plugin_actions ) ) {
+                                                    foreach ( $plugin_actions as $action ) {
+                                                        echo '<span class="flygit-action-link">' . wp_kses_post( $action ) . '</span>';
+                                                    }
+                                                }
+                                                ?>
+
+                                                <?php if ( $plugin_installation ) : ?>
+                                                    <form class="flygit-inline-form" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" onsubmit="return confirm('<?php echo esc_js( $plugin_uninstall_message ); ?>');">
+                                                        <?php wp_nonce_field( 'flygit_uninstall' ); ?>
+                                                        <input type="hidden" name="action" value="flygit_uninstall" />
+                                                        <input type="hidden" name="installation_id" value="<?php echo esc_attr( $plugin_installation['id'] ); ?>" />
+                                                        <button type="submit" class="button flygit-button-danger flygit-action-button"><?php esc_html_e( 'Uninstall', 'flygit' ); ?></button>
+                                                    </form>
+                                                <?php endif; ?>
+                                            </div>
+
+                                            <?php if ( $plugin_installation ) : ?>
+                                                <div class="flygit-collection-settings">
+                                                    <h4><?php esc_html_e( 'FlyGit Settings', 'flygit' ); ?></h4>
+
+                                                    <?php if ( ! empty( $plugin_installation['repository_url'] ) || ! empty( $plugin_installation['branch'] ) ) : ?>
+                                                        <ul class="flygit-meta-list">
+                                                            <?php if ( ! empty( $plugin_installation['repository_url'] ) ) : ?>
+                                                                <li><strong><?php esc_html_e( 'Repository:', 'flygit' ); ?></strong> <a href="<?php echo esc_url( $plugin_installation['repository_url'] ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $plugin_installation['repository_url'] ); ?></a></li>
+                                                            <?php endif; ?>
+                                                            <?php if ( ! empty( $plugin_installation['branch'] ) ) : ?>
+                                                                <li><strong><?php esc_html_e( 'Branch:', 'flygit' ); ?></strong> <?php echo esc_html( $plugin_installation['branch'] ); ?></li>
+                                                            <?php endif; ?>
+                                                        </ul>
+                                                    <?php endif; ?>
+
+                                                    <?php $webhook_element_id = 'flygit-webhook-url-' . sanitize_html_class( $plugin_installation['id'] ); ?>
+                                                    <div class="flygit-webhook-block">
+                                                        <span class="flygit-webhook-label"><?php esc_html_e( 'Webhook Endpoint', 'flygit' ); ?></span>
+                                                        <div class="flygit-webhook-endpoint">
+                                                            <code id="<?php echo esc_attr( $webhook_element_id ); ?>"><?php echo esc_html( $plugin_installation['webhook_url'] ); ?></code>
+                                                            <button type="button" class="button flygit-copy" data-target="<?php echo esc_attr( $webhook_element_id ); ?>"><?php esc_html_e( 'Copy', 'flygit' ); ?></button>
+                                                        </div>
+                                                        <p class="description"><?php esc_html_e( 'Send a POST request to this endpoint to pull the latest code for the installation.', 'flygit' ); ?></p>
+                                                    </div>
+
+                                                    <form class="flygit-form" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+                                                        <?php wp_nonce_field( 'flygit_webhook_settings' ); ?>
+                                                        <input type="hidden" name="action" value="flygit_save_webhook_settings" />
+                                                        <input type="hidden" name="installation_id" value="<?php echo esc_attr( $plugin_installation['id'] ); ?>" />
+                                                        <label>
+                                                            <?php esc_html_e( 'Webhook Secret (optional)', 'flygit' ); ?>
+                                                            <input type="text" name="webhook_secret" value="<?php echo esc_attr( $plugin_installation['webhook_secret'] ); ?>" placeholder="<?php esc_attr_e( 'Secret token to verify requests', 'flygit' ); ?>" />
+                                                        </label>
+                                                        <p class="description"><?php esc_html_e( 'When set, authenticate the webhook using the X-Flygit-Secret header, a "secret" payload field, GitHub\'s X-Hub-Signature headers or GitLab\'s X-Gitlab-Token header.', 'flygit' ); ?></p>
+                                                        <p class="description"><?php esc_html_e( 'Payloads can be sent as application/json (recommended) or application/x-www-form-urlencoded.', 'flygit' ); ?></p>
+                                                        <button type="submit" class="button button-primary"><?php esc_html_e( 'Save Webhook Settings', 'flygit' ); ?></button>
+                                                    </form>
+                                                </div>
+                                            <?php endif; ?>
+                                        </div>
+                                    </details>
+                                <?php endforeach; ?>
+                            <?php else : ?>
+                                <p class="flygit-empty-state">
+                                    <span class="dashicons dashicons-admin-plugins" aria-hidden="true"></span>
+                                    <?php esc_html_e( 'No plugins installed with FlyGit yet.', 'flygit' ); ?>
+                                </p>
+                            <?php endif; ?>
+                        </div>
+                    </div>
+
+                    <div class="flygit-card-side" id="flygit-install-plugin">
+                        <div class="flygit-side-card">
+                            <h3><?php esc_html_e( 'Install Plugin', 'flygit' ); ?></h3>
+                            <p class="flygit-side-description"><?php esc_html_e( 'Clone any Git repository and install it as a plugin with a single action. Perfect for bespoke or private tools.', 'flygit' ); ?></p>
+
+                            <form class="flygit-form" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+                                <?php wp_nonce_field( 'flygit_install' ); ?>
+                                <input type="hidden" name="action" value="flygit_install" />
+                                <input type="hidden" name="install_type" value="plugin" />
+
+                                <label>
+                                    <?php esc_html_e( 'Repository URL', 'flygit' ); ?>
+                                    <input type="url" name="repository_url" placeholder="https://github.com/owner/repo" required />
+                                </label>
+
+                                <label>
+                                    <?php esc_html_e( 'Branch', 'flygit' ); ?>
+                                    <input type="text" name="branch" placeholder="main" />
+                                </label>
+
+                                <label>
+                                    <?php esc_html_e( 'Access Token (optional)', 'flygit' ); ?>
+                                    <input type="password" name="access_token" autocomplete="off" />
+                                </label>
+
+                                <button type="submit" class="button button-primary flygit-submit-button"><?php esc_html_e( 'Install Plugin', 'flygit' ); ?></button>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </section>
+        </div>
+
+        <section class="flygit-card flygit-card--full" id="flygit-snippets">
+            <div class="flygit-card-header">
+                <div>
+                    <span class="flygit-eyebrow"><?php esc_html_e( 'Code Snippets', 'flygit' ); ?></span>
+                    <h2><?php esc_html_e( 'Snippet Repositories', 'flygit' ); ?></h2>
+                </div>
+                <span class="flygit-counter"><?php echo esc_html( number_format_i18n( $snippet_total ) ); ?></span>
+            </div>
+
+            <div class="flygit-card-body flygit-card-body--split">
+                <div class="flygit-card-main">
+                    <p class="flygit-section-description">
+                        <?php esc_html_e( 'Import reusable PHP snippets directly from Git repositories. Imported snippets are stored in:', 'flygit' ); ?>
+                        <code><?php echo esc_html( $snippet_storage_display ); ?></code>
+                        <?php if ( $snippet_storage_display !== $snippet_storage_path ) : ?>
+                            <span class="flygit-snippets-path-alt">(<?php echo esc_html( $snippet_storage_path ); ?>)</span>
+                        <?php endif; ?>
+                    </p>
+
+                    <div class="flygit-collection" role="list">
+                        <?php if ( ! empty( $snippet_installations ) ) : ?>
+                            <?php foreach ( $snippet_installations as $snippet_installation ) : ?>
+                                <?php
+                                $snippet_files   = isset( $snippet_installation['files'] ) && is_array( $snippet_installation['files'] ) ? $snippet_installation['files'] : array();
+                                $snippet_sources = isset( $snippet_installation['sources'] ) && is_array( $snippet_installation['sources'] ) ? $snippet_installation['sources'] : array();
+                                $snippet_count   = isset( $snippet_installation['file_count'] ) ? (int) $snippet_installation['file_count'] : count( $snippet_files );
+                                $snippet_last    = isset( $snippet_installation['last_import'] ) ? $snippet_installation['last_import'] : '';
+                                $snippet_uninstall_label   = ! empty( $snippet_installation['name'] ) ? $snippet_installation['name'] : $snippet_installation['id'];
+                                $snippet_uninstall_message = sprintf( esc_html__( 'Are you sure you want to uninstall the snippet repository "%s"?', 'flygit' ), $snippet_uninstall_label );
+                                $snippet_webhook_element_id = 'flygit-webhook-url-' . sanitize_html_class( $snippet_installation['id'] );
+                                $snippet_display_name      = ! empty( $snippet_installation['name'] ) ? $snippet_installation['name'] : ( isset( $snippet_installation['slug'] ) ? $snippet_installation['slug'] : __( 'Snippet Repository', 'flygit' ) );
+                                ?>
+                                <details class="flygit-collection-item" role="listitem">
+                                    <summary class="flygit-collection-summary">
+                                        <div class="flygit-collection-summary-main">
+                                            <span class="flygit-collection-name"><?php echo esc_html( $snippet_display_name ); ?></span>
+                                        </div>
+                                        <div class="flygit-collection-summary-meta">
+                                            <span><?php printf( esc_html__( '%d files', 'flygit' ), $snippet_count ); ?></span>
+                                            <?php if ( ! empty( $snippet_last ) ) : ?>
+                                                <span><?php printf( esc_html__( 'Last import: %s', 'flygit' ), esc_html( $snippet_last ) ); ?></span>
+                                            <?php endif; ?>
+                                        </div>
+                                    </summary>
+                                    <div class="flygit-collection-body">
+                                        <ul class="flygit-meta-list">
+                                            <?php if ( ! empty( $snippet_installation['repository_url'] ) ) : ?>
+                                                <li><strong><?php esc_html_e( 'Repository:', 'flygit' ); ?></strong> <a href="<?php echo esc_url( $snippet_installation['repository_url'] ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $snippet_installation['repository_url'] ); ?></a></li>
+                                            <?php endif; ?>
+                                            <?php if ( ! empty( $snippet_installation['branch'] ) ) : ?>
+                                                <li><strong><?php esc_html_e( 'Branch:', 'flygit' ); ?></strong> <?php echo esc_html( $snippet_installation['branch'] ); ?></li>
+                                            <?php endif; ?>
+                                            <?php if ( ! empty( $snippet_files ) ) : ?>
+                                                <li>
+                                                    <strong><?php esc_html_e( 'Imported Files:', 'flygit' ); ?></strong>
+                                                    <ul class="flygit-sublist">
+                                                        <?php foreach ( $snippet_files as $file_name ) : ?>
+                                                            <?php $source = isset( $snippet_sources[ $file_name ] ) ? $snippet_sources[ $file_name ] : ''; ?>
+                                                            <li>
+                                                                <code><?php echo esc_html( $file_name ); ?></code>
+                                                                <?php if ( ! empty( $source ) ) : ?>
+                                                                    <span class="description">(<?php echo esc_html( $source ); ?>)</span>
+                                                                <?php endif; ?>
+                                                            </li>
+                                                        <?php endforeach; ?>
+                                                    </ul>
+                                                </li>
+                                            <?php endif; ?>
+                                        </ul>
+
+                                        <div class="flygit-action-row">
+                                            <form class="flygit-inline-form" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+                                                <?php wp_nonce_field( 'flygit_import_snippet' ); ?>
+                                                <input type="hidden" name="action" value="flygit_import_snippet" />
+                                                <input type="hidden" name="installation_id" value="<?php echo esc_attr( $snippet_installation['id'] ); ?>" />
+                                                <button type="submit" class="button flygit-action-button"><?php esc_html_e( 'Pull Latest', 'flygit' ); ?></button>
+                                            </form>
+                                            <form class="flygit-inline-form" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" onsubmit="return confirm('<?php echo esc_js( $snippet_uninstall_message ); ?>');">
                                                 <?php wp_nonce_field( 'flygit_uninstall' ); ?>
                                                 <input type="hidden" name="action" value="flygit_uninstall" />
-                                                <input type="hidden" name="installation_id" value="<?php echo esc_attr( $theme_installation['id'] ); ?>" />
-                                                <button type="submit" class="button flygit-button-danger"><?php esc_html_e( 'Uninstall', 'flygit' ); ?></button>
+                                                <input type="hidden" name="installation_id" value="<?php echo esc_attr( $snippet_installation['id'] ); ?>" />
+                                                <button type="submit" class="button flygit-button-danger flygit-action-button"><?php esc_html_e( 'Uninstall', 'flygit' ); ?></button>
                                             </form>
-                                        <?php endif; ?>
-                                    <?php endif; ?>
-                                </div>
-
-                                <?php if ( $theme_installation ) : ?>
-                                    <div class="flygit-installation-settings">
-                                        <h4><?php esc_html_e( 'FlyGit Settings', 'flygit' ); ?></h4>
-
-                                        <?php if ( ! empty( $theme_installation['repository_url'] ) || ! empty( $theme_installation['branch'] ) ) : ?>
-                                            <ul class="flygit-meta">
-                                                <?php if ( ! empty( $theme_installation['repository_url'] ) ) : ?>
-                                                    <li><strong><?php esc_html_e( 'Repository:', 'flygit' ); ?></strong> <a href="<?php echo esc_url( $theme_installation['repository_url'] ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $theme_installation['repository_url'] ); ?></a></li>
-                                                <?php endif; ?>
-                                                <?php if ( ! empty( $theme_installation['branch'] ) ) : ?>
-                                                    <li><strong><?php esc_html_e( 'Branch:', 'flygit' ); ?></strong> <?php echo esc_html( $theme_installation['branch'] ); ?></li>
-                                                <?php endif; ?>
-                                            </ul>
-                                        <?php endif; ?>
-
-                                        <?php $webhook_element_id = 'flygit-webhook-url-' . sanitize_html_class( $theme_installation['id'] ); ?>
-                                        <div class="flygit-installation-webhook">
-                                            <span class="flygit-installation-subtitle"><?php esc_html_e( 'Webhook Endpoint', 'flygit' ); ?></span>
-                                            <div class="flygit-webhook-endpoint">
-                                                <code id="<?php echo esc_attr( $webhook_element_id ); ?>"><?php echo esc_html( $theme_installation['webhook_url'] ); ?></code>
-                                                <button type="button" class="button flygit-copy" data-target="<?php echo esc_attr( $webhook_element_id ); ?>"><?php esc_html_e( 'Copy', 'flygit' ); ?></button>
-                                            </div>
-                                            <p class="description"><?php esc_html_e( 'Send a POST request to this endpoint to pull the latest code for the installation.', 'flygit' ); ?></p>
                                         </div>
 
-                                        <form class="flygit-form" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
-                                            <?php wp_nonce_field( 'flygit_webhook_settings' ); ?>
-                                            <input type="hidden" name="action" value="flygit_save_webhook_settings" />
-                                            <input type="hidden" name="installation_id" value="<?php echo esc_attr( $theme_installation['id'] ); ?>" />
-                                            <label>
-                                                <?php esc_html_e( 'Webhook Secret (optional)', 'flygit' ); ?>
-                                                <input type="text" name="webhook_secret" value="<?php echo esc_attr( $theme_installation['webhook_secret'] ); ?>" placeholder="<?php esc_attr_e( 'Secret token to verify requests', 'flygit' ); ?>" />
-                                            </label>
-                                            <p class="description"><?php esc_html_e( 'When set, authenticate the webhook using the X-Flygit-Secret header, a "secret" payload field, GitHub\'s X-Hub-Signature headers or GitLab\'s X-Gitlab-Token header.', 'flygit' ); ?></p>
-                                            <p class="description"><?php esc_html_e( 'Payloads can be sent as application/json (recommended) or application/x-www-form-urlencoded.', 'flygit' ); ?></p>
-                                            <button type="submit" class="button button-primary"><?php esc_html_e( 'Save Webhook Settings', 'flygit' ); ?></button>
-                                        </form>
-                                    </div>
-                                <?php endif; ?>
-                            </div>
-                        </details>
-                        <?php endforeach; ?>
-                    <?php else : ?>
-                        <p class="description flygit-empty-state">
-                            <span class="dashicons dashicons-admin-appearance" aria-hidden="true"></span>
-                            <?php esc_html_e( 'No themes installed with FlyGit yet.', 'flygit' ); ?>
-                        </p>
-                    <?php endif; ?>
-                </div>
-                <footer class="flygit-section-footer" id="flygit-install-theme">
-                    <h3><?php esc_html_e( 'Install Theme', 'flygit' ); ?></h3>
-                    <form class="flygit-form" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
-                        <?php wp_nonce_field( 'flygit_install' ); ?>
-                        <input type="hidden" name="action" value="flygit_install" />
-                        <input type="hidden" name="install_type" value="theme" />
+                                        <div class="flygit-collection-settings">
+                                            <h4><?php esc_html_e( 'FlyGit Settings', 'flygit' ); ?></h4>
 
-                        <label>
-                            <?php esc_html_e( 'Repository URL', 'flygit' ); ?>
-                            <input type="url" name="repository_url" placeholder="https://github.com/owner/repo" required />
-                        </label>
-                        <label>
-                            <?php esc_html_e( 'Branch', 'flygit' ); ?>
-                            <input type="text" name="branch" placeholder="main" />
-                        </label>
-                        <label>
-                            <?php esc_html_e( 'Access Token (optional)', 'flygit' ); ?>
-                            <input type="password" name="access_token" autocomplete="off" />
-                        </label>
-                        <button type="submit" class="button button-primary">
-                            <?php esc_html_e( 'Install Theme', 'flygit' ); ?>
-                        </button>
-                    </form>
-                </footer>
-            </section>
-        </div>
+                                            <form class="flygit-form" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+                                                <?php wp_nonce_field( 'flygit_snippet_settings' ); ?>
+                                                <input type="hidden" name="action" value="flygit_update_snippet_settings" />
+                                                <input type="hidden" name="installation_id" value="<?php echo esc_attr( $snippet_installation['id'] ); ?>" />
+                                                <label>
+                                                    <?php esc_html_e( 'Display Name', 'flygit' ); ?>
+                                                    <input type="text" name="name" value="<?php echo esc_attr( $snippet_display_name ); ?>" required />
+                                                </label>
+                                                <button type="submit" class="button flygit-action-button"><?php esc_html_e( 'Save Name', 'flygit' ); ?></button>
+                                            </form>
 
-        <div class="flygit-column">
-            <section class="flygit-section">
-                <header class="flygit-section-header">
-                    <h2>
-                        <?php esc_html_e( 'Installed Plugins', 'flygit' ); ?>
-                        <span class="flygit-badge"><?php echo esc_html( $installed_count['plugins'] ); ?></span>
-                    </h2>
-                </header>
-                <div class="flygit-list">
-                    <?php if ( ! empty( $plugins ) ) : ?>
-                        <?php foreach ( $plugins as $plugin_file => $plugin_data ) : ?>
-                        <?php
-                        $plugin_slug         = dirname( $plugin_file );
-                        $plugin_installation = ( '.' !== $plugin_slug && isset( $plugin_installations_map[ $plugin_slug ] ) ) ? $plugin_installations_map[ $plugin_slug ] : null;
-                        $is_active           = in_array( $plugin_file, $active_plugins, true );
-                        $activate_url        = wp_nonce_url(
-                            admin_url( 'plugins.php?action=activate&plugin=' . $plugin_file ),
-                            'activate-plugin_' . $plugin_file
-                        );
-                        $deactivate_url = wp_nonce_url(
-                            admin_url( 'plugins.php?action=deactivate&plugin=' . $plugin_file ),
-                            'deactivate-plugin_' . $plugin_file
-                        );
-                        $plugin_actions = apply_filters( 'plugin_action_links_' . $plugin_file, array(), $plugin_file, $plugin_data, 'flygit' );
-                        $plugin_actions = apply_filters( 'plugin_action_links', $plugin_actions, $plugin_file, $plugin_data, 'flygit' );
-                        $plugin_uninstall_label   = ! empty( $plugin_data['Name'] ) ? $plugin_data['Name'] : $plugin_slug;
-                        $plugin_uninstall_message = sprintf( esc_html__( 'Are you sure you want to uninstall the plugin "%s"?', 'flygit' ), $plugin_uninstall_label );
-                        ?>
-                        <details class="flygit-item">
-                            <summary class="flygit-item-summary">
-                                <span class="flygit-item-title"><?php echo esc_html( $plugin_data['Name'] ); ?></span>
-                                <span class="flygit-item-meta">
-                                    <?php if ( $is_active ) : ?>
-                                        <span class="flygit-status flygit-status-active"><?php esc_html_e( 'Active', 'flygit' ); ?></span>
-                                    <?php else : ?>
-                                        <span class="flygit-status flygit-status-inactive"><?php esc_html_e( 'Inactive', 'flygit' ); ?></span>
-                                    <?php endif; ?>
-                                    <span><?php printf( esc_html__( 'Version %s', 'flygit' ), esc_html( $plugin_data['Version'] ) ); ?></span>
-                                </span>
-                            </summary>
-                            <div class="flygit-item-body">
-                                <?php if ( ! empty( $plugin_data['Description'] ) ) : ?>
-                                    <p class="flygit-description"><?php echo esc_html( $plugin_data['Description'] ); ?></p>
-                                <?php endif; ?>
-
-                                <ul class="flygit-meta">
-                                    <li><strong><?php esc_html_e( 'Author:', 'flygit' ); ?></strong> <?php echo wp_kses_post( $plugin_data['Author'] ); ?></li>
-                                    <?php if ( ! empty( $plugin_data['PluginURI'] ) ) : ?>
-                                        <li><strong><?php esc_html_e( 'Website:', 'flygit' ); ?></strong> <a href="<?php echo esc_url( $plugin_data['PluginURI'] ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $plugin_data['PluginURI'] ); ?></a></li>
-                                    <?php endif; ?>
-                                    <li><strong><?php esc_html_e( 'Path:', 'flygit' ); ?></strong> <code><?php echo esc_html( $plugin_file ); ?></code></li>
-                                </ul>
-
-                                <div class="flygit-actions">
-                                    <?php if ( $is_active ) : ?>
-                                        <a class="button" href="<?php echo esc_url( $deactivate_url ); ?>"><?php esc_html_e( 'Deactivate', 'flygit' ); ?></a>
-                                    <?php else : ?>
-                                        <a class="button button-primary" href="<?php echo esc_url( $activate_url ); ?>"><?php esc_html_e( 'Activate', 'flygit' ); ?></a>
-                                    <?php endif; ?>
-
-                                    <?php
-                                    if ( ! empty( $plugin_actions ) && is_array( $plugin_actions ) ) {
-                                        foreach ( $plugin_actions as $action ) {
-                                            echo '<span class="flygit-action-link">' . wp_kses_post( $action ) . '</span>';
-                                        }
-                                    }
-                                    ?>
-                                    <?php if ( $plugin_installation ) : ?>
-                                        <form class="flygit-inline-form" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" onsubmit="return confirm('<?php echo esc_js( $plugin_uninstall_message ); ?>');">
-                                            <?php wp_nonce_field( 'flygit_uninstall' ); ?>
-                                            <input type="hidden" name="action" value="flygit_uninstall" />
-                                            <input type="hidden" name="installation_id" value="<?php echo esc_attr( $plugin_installation['id'] ); ?>" />
-                                            <button type="submit" class="button flygit-button-danger"><?php esc_html_e( 'Uninstall', 'flygit' ); ?></button>
-                                        </form>
-                                    <?php endif; ?>
-                                </div>
-
-                                <?php if ( $plugin_installation ) : ?>
-                                    <div class="flygit-installation-settings">
-                                        <h4><?php esc_html_e( 'FlyGit Settings', 'flygit' ); ?></h4>
-
-                                        <?php if ( ! empty( $plugin_installation['repository_url'] ) || ! empty( $plugin_installation['branch'] ) ) : ?>
-                                            <ul class="flygit-meta">
-                                                <?php if ( ! empty( $plugin_installation['repository_url'] ) ) : ?>
-                                                    <li><strong><?php esc_html_e( 'Repository:', 'flygit' ); ?></strong> <a href="<?php echo esc_url( $plugin_installation['repository_url'] ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $plugin_installation['repository_url'] ); ?></a></li>
-                                                <?php endif; ?>
-                                                <?php if ( ! empty( $plugin_installation['branch'] ) ) : ?>
-                                                    <li><strong><?php esc_html_e( 'Branch:', 'flygit' ); ?></strong> <?php echo esc_html( $plugin_installation['branch'] ); ?></li>
-                                                <?php endif; ?>
-                                            </ul>
-                                        <?php endif; ?>
-
-                                        <?php $webhook_element_id = 'flygit-webhook-url-' . sanitize_html_class( $plugin_installation['id'] ); ?>
-                                        <div class="flygit-installation-webhook">
-                                            <span class="flygit-installation-subtitle"><?php esc_html_e( 'Webhook Endpoint', 'flygit' ); ?></span>
-                                            <div class="flygit-webhook-endpoint">
-                                                <code id="<?php echo esc_attr( $webhook_element_id ); ?>"><?php echo esc_html( $plugin_installation['webhook_url'] ); ?></code>
-                                                <button type="button" class="button flygit-copy" data-target="<?php echo esc_attr( $webhook_element_id ); ?>"><?php esc_html_e( 'Copy', 'flygit' ); ?></button>
+                                            <?php $webhook_element_id = 'flygit-webhook-url-' . sanitize_html_class( $snippet_installation['id'] ); ?>
+                                            <div class="flygit-webhook-block">
+                                                <span class="flygit-webhook-label"><?php esc_html_e( 'Webhook Endpoint', 'flygit' ); ?></span>
+                                                <div class="flygit-webhook-endpoint">
+                                                    <code id="<?php echo esc_attr( $webhook_element_id ); ?>"><?php echo esc_html( $snippet_installation['webhook_url'] ); ?></code>
+                                                    <button type="button" class="button flygit-copy" data-target="<?php echo esc_attr( $webhook_element_id ); ?>"><?php esc_html_e( 'Copy', 'flygit' ); ?></button>
+                                                </div>
+                                                <p class="description"><?php esc_html_e( 'Send a POST request to this endpoint to pull the latest code for the installation.', 'flygit' ); ?></p>
                                             </div>
-                                            <p class="description"><?php esc_html_e( 'Send a POST request to this endpoint to pull the latest code for the installation.', 'flygit' ); ?></p>
+
+                                            <form class="flygit-form" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+                                                <?php wp_nonce_field( 'flygit_webhook_settings' ); ?>
+                                                <input type="hidden" name="action" value="flygit_save_webhook_settings" />
+                                                <input type="hidden" name="installation_id" value="<?php echo esc_attr( $snippet_installation['id'] ); ?>" />
+                                                <label>
+                                                    <?php esc_html_e( 'Webhook Secret (optional)', 'flygit' ); ?>
+                                                    <input type="text" name="webhook_secret" value="<?php echo esc_attr( $snippet_installation['webhook_secret'] ); ?>" placeholder="<?php esc_attr_e( 'Secret token to verify requests', 'flygit' ); ?>" />
+                                                </label>
+                                                <p class="description"><?php esc_html_e( 'When set, authenticate the webhook using the same headers supported for themes and plugins.', 'flygit' ); ?></p>
+                                                <button type="submit" class="button button-primary"><?php esc_html_e( 'Save Webhook Settings', 'flygit' ); ?></button>
+                                            </form>
                                         </div>
-
-                                        <form class="flygit-form" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
-                                            <?php wp_nonce_field( 'flygit_webhook_settings' ); ?>
-                                            <input type="hidden" name="action" value="flygit_save_webhook_settings" />
-                                            <input type="hidden" name="installation_id" value="<?php echo esc_attr( $plugin_installation['id'] ); ?>" />
-                                            <label>
-                                                <?php esc_html_e( 'Webhook Secret (optional)', 'flygit' ); ?>
-                                                <input type="text" name="webhook_secret" value="<?php echo esc_attr( $plugin_installation['webhook_secret'] ); ?>" placeholder="<?php esc_attr_e( 'Secret token to verify requests', 'flygit' ); ?>" />
-                                            </label>
-                                            <p class="description"><?php esc_html_e( 'When set, authenticate the webhook using the X-Flygit-Secret header, a "secret" payload field, GitHub\'s X-Hub-Signature headers or GitLab\'s X-Gitlab-Token header.', 'flygit' ); ?></p>
-                                            <p class="description"><?php esc_html_e( 'Payloads can be sent as application/json (recommended) or application/x-www-form-urlencoded.', 'flygit' ); ?></p>
-                                            <button type="submit" class="button button-primary"><?php esc_html_e( 'Save Webhook Settings', 'flygit' ); ?></button>
-                                        </form>
                                     </div>
-                                <?php endif; ?>
-                            </div>
-                        </details>
-                        <?php endforeach; ?>
-                    <?php else : ?>
-                        <p class="description flygit-empty-state">
-                            <span class="dashicons dashicons-admin-plugins" aria-hidden="true"></span>
-                            <?php esc_html_e( 'No plugins installed with FlyGit yet.', 'flygit' ); ?>
-                        </p>
-                    <?php endif; ?>
-                </div>
-                <footer class="flygit-section-footer" id="flygit-install-plugin">
-                    <h3><?php esc_html_e( 'Install Plugin', 'flygit' ); ?></h3>
-                    <form class="flygit-form" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
-                        <?php wp_nonce_field( 'flygit_install' ); ?>
-                        <input type="hidden" name="action" value="flygit_install" />
-                        <input type="hidden" name="install_type" value="plugin" />
+                                </details>
+                            <?php endforeach; ?>
+                        <?php else : ?>
+                            <p class="flygit-empty-state">
+                                <span class="dashicons dashicons-media-code" aria-hidden="true"></span>
+                                <?php esc_html_e( 'No snippet repositories imported yet.', 'flygit' ); ?>
+                            </p>
+                        <?php endif; ?>
+                    </div>
 
-                        <label>
-                            <?php esc_html_e( 'Repository URL', 'flygit' ); ?>
-                            <input type="url" name="repository_url" placeholder="https://github.com/owner/repo" required />
-                        </label>
-                        <label>
-                            <?php esc_html_e( 'Branch', 'flygit' ); ?>
-                            <input type="text" name="branch" placeholder="main" />
-                        </label>
-                        <label>
-                            <?php esc_html_e( 'Access Token (optional)', 'flygit' ); ?>
-                            <input type="password" name="access_token" autocomplete="off" />
-                        </label>
-                        <button type="submit" class="button button-primary">
-                            <?php esc_html_e( 'Install Plugin', 'flygit' ); ?>
-                        </button>
-                    </form>
-                </footer>
-            </section>
-        </div>
-</div>
-
-<section class="flygit-section flygit-snippets-section">
-    <header class="flygit-section-header">
-        <h2>
-            <?php esc_html_e( 'Installed Snippet Repositories', 'flygit' ); ?>
-            <span class="flygit-badge"><?php echo esc_html( isset( $installed_count['snippets'] ) ? $installed_count['snippets'] : 0 ); ?></span>
-        </h2>
-    </header>
-    <div class="flygit-snippets-body">
-        <p class="description">
-            <?php esc_html_e( 'Import reusable PHP snippets directly from Git repositories. Imported snippets are stored in:', 'flygit' ); ?>
-            <code><?php echo esc_html( $snippet_storage_display ); ?></code>
-            <?php if ( $snippet_storage_display !== $snippet_storage_path ) : ?>
-                <span class="flygit-snippets-path-alt">(<?php echo esc_html( $snippet_storage_path ); ?>)</span>
-            <?php endif; ?>
-        </p>
-
-        <div class="flygit-list">
-            <?php if ( ! empty( $snippet_installations ) ) : ?>
-                <?php foreach ( $snippet_installations as $snippet_installation ) : ?>
-                    <?php
-                    $snippet_files   = isset( $snippet_installation['files'] ) && is_array( $snippet_installation['files'] ) ? $snippet_installation['files'] : array();
-                    $snippet_sources = isset( $snippet_installation['sources'] ) && is_array( $snippet_installation['sources'] ) ? $snippet_installation['sources'] : array();
-                    $snippet_count   = isset( $snippet_installation['file_count'] ) ? (int) $snippet_installation['file_count'] : count( $snippet_files );
-                    $snippet_last    = isset( $snippet_installation['last_import'] ) ? $snippet_installation['last_import'] : '';
-                    $snippet_uninstall_label = ! empty( $snippet_installation['name'] ) ? $snippet_installation['name'] : $snippet_installation['id'];
-                    $snippet_uninstall_message = sprintf( esc_html__( 'Are you sure you want to uninstall the snippet repository "%s"?', 'flygit' ), $snippet_uninstall_label );
-                    $snippet_webhook_element_id = 'flygit-webhook-url-' . sanitize_html_class( $snippet_installation['id'] );
-                    $snippet_display_name      = ! empty( $snippet_installation['name'] ) ? $snippet_installation['name'] : ( isset( $snippet_installation['slug'] ) ? $snippet_installation['slug'] : __( 'Snippet Repository', 'flygit' ) );
-                    ?>
-                    <details class="flygit-item">
-                        <summary class="flygit-item-summary">
-                            <span class="flygit-item-title"><?php echo esc_html( $snippet_display_name ); ?></span>
-                            <span class="flygit-item-meta">
-                                <span><?php printf( esc_html__( '%d files', 'flygit' ), $snippet_count ); ?></span>
-                                <?php if ( ! empty( $snippet_last ) ) : ?>
-                                    <span><?php printf( esc_html__( 'Last import: %s', 'flygit' ), esc_html( $snippet_last ) ); ?></span>
-                                <?php endif; ?>
-                            </span>
-                        </summary>
-                        <div class="flygit-item-body">
-                            <ul class="flygit-meta">
-                                <?php if ( ! empty( $snippet_installation['repository_url'] ) ) : ?>
-                                    <li><strong><?php esc_html_e( 'Repository:', 'flygit' ); ?></strong> <a href="<?php echo esc_url( $snippet_installation['repository_url'] ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $snippet_installation['repository_url'] ); ?></a></li>
-                                <?php endif; ?>
-                                <?php if ( ! empty( $snippet_installation['branch'] ) ) : ?>
-                                    <li><strong><?php esc_html_e( 'Branch:', 'flygit' ); ?></strong> <?php echo esc_html( $snippet_installation['branch'] ); ?></li>
-                                <?php endif; ?>
-                                <?php if ( ! empty( $snippet_files ) ) : ?>
-                                    <li>
-                                        <strong><?php esc_html_e( 'Imported Files:', 'flygit' ); ?></strong>
-                                        <ul class="flygit-sublist">
-                                            <?php foreach ( $snippet_files as $file_name ) : ?>
-                                                <?php $source = isset( $snippet_sources[ $file_name ] ) ? $snippet_sources[ $file_name ] : ''; ?>
-                                                <li>
-                                                    <code><?php echo esc_html( $file_name ); ?></code>
-                                                    <?php if ( ! empty( $source ) ) : ?>
-                                                        <span class="description">(<?php echo esc_html( $source ); ?>)</span>
-                                                    <?php endif; ?>
-                                                </li>
-                                            <?php endforeach; ?>
-                                        </ul>
-                                    </li>
-                                <?php endif; ?>
-                            </ul>
-
-                            <div class="flygit-actions">
-                                <form class="flygit-inline-form" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
-                                    <?php wp_nonce_field( 'flygit_import_snippet' ); ?>
-                                    <input type="hidden" name="action" value="flygit_import_snippet" />
-                                    <input type="hidden" name="installation_id" value="<?php echo esc_attr( $snippet_installation['id'] ); ?>" />
-                                    <button type="submit" class="button"><?php esc_html_e( 'Pull Latest', 'flygit' ); ?></button>
-                                </form>
-                                <form class="flygit-inline-form" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" onsubmit="return confirm('<?php echo esc_js( $snippet_uninstall_message ); ?>');">
-                                    <?php wp_nonce_field( 'flygit_uninstall' ); ?>
-                                    <input type="hidden" name="action" value="flygit_uninstall" />
-                                    <input type="hidden" name="installation_id" value="<?php echo esc_attr( $snippet_installation['id'] ); ?>" />
-                                    <button type="submit" class="button flygit-button-danger"><?php esc_html_e( 'Uninstall', 'flygit' ); ?></button>
-                                </form>
-                            </div>
-
-                            <div class="flygit-installation-settings">
-                                <h4><?php esc_html_e( 'FlyGit Settings', 'flygit' ); ?></h4>
-
-                                <form class="flygit-form" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
-                                    <?php wp_nonce_field( 'flygit_snippet_settings' ); ?>
-                                    <input type="hidden" name="action" value="flygit_update_snippet_settings" />
-                                    <input type="hidden" name="installation_id" value="<?php echo esc_attr( $snippet_installation['id'] ); ?>" />
-                                    <label>
-                                        <?php esc_html_e( 'Display Name', 'flygit' ); ?>
-                                        <input type="text" name="name" value="<?php echo esc_attr( $snippet_display_name ); ?>" required />
-                                    </label>
-                                    <button type="submit" class="button"><?php esc_html_e( 'Save Name', 'flygit' ); ?></button>
-                                </form>
-
-                                <div class="flygit-installation-webhook">
-                                    <span class="flygit-installation-subtitle"><?php esc_html_e( 'Webhook Endpoint', 'flygit' ); ?></span>
-                                    <div class="flygit-webhook-endpoint">
-                                        <code id="<?php echo esc_attr( $snippet_webhook_element_id ); ?>"><?php echo esc_html( $snippet_installation['webhook_url'] ); ?></code>
-                                        <button type="button" class="button flygit-copy" data-target="<?php echo esc_attr( $snippet_webhook_element_id ); ?>"><?php esc_html_e( 'Copy', 'flygit' ); ?></button>
-                                    </div>
-                                    <p class="description"><?php esc_html_e( 'Send a POST request to this endpoint to pull the latest snippets.', 'flygit' ); ?></p>
-                                </div>
-
-                                <form class="flygit-form" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
-                                    <?php wp_nonce_field( 'flygit_webhook_settings' ); ?>
-                                    <input type="hidden" name="action" value="flygit_save_webhook_settings" />
-                                    <input type="hidden" name="installation_id" value="<?php echo esc_attr( $snippet_installation['id'] ); ?>" />
-                                    <label>
-                                        <?php esc_html_e( 'Webhook Secret (optional)', 'flygit' ); ?>
-                                        <input type="text" name="webhook_secret" value="<?php echo esc_attr( $snippet_installation['webhook_secret'] ); ?>" placeholder="<?php esc_attr_e( 'Secret token to verify requests', 'flygit' ); ?>" />
-                                    </label>
-                                    <p class="description"><?php esc_html_e( 'When set, authenticate the webhook using the same headers supported for themes and plugins.', 'flygit' ); ?></p>
-                                    <button type="submit" class="button button-primary"><?php esc_html_e( 'Save Webhook Settings', 'flygit' ); ?></button>
-                                </form>
-                            </div>
+                    <?php if ( ! empty( $code_snippet_error ) ) : ?>
+                        <div class="flygit-alert flygit-alert-error">
+                            <span class="flygit-alert-icon dashicons dashicons-warning" aria-hidden="true"></span>
+                            <span class="flygit-alert-message"><?php echo esc_html( $code_snippet_error ); ?></span>
                         </div>
-                    </details>
-                <?php endforeach; ?>
-            <?php else : ?>
-                <p class="description flygit-empty-state">
-                    <span class="dashicons dashicons-media-code" aria-hidden="true"></span>
-                    <?php esc_html_e( 'No snippet repositories imported yet.', 'flygit' ); ?>
-                </p>
-            <?php endif; ?>
-        </div>
+                    <?php endif; ?>
 
-        <?php if ( ! empty( $code_snippet_error ) ) : ?>
-            <div class="notice notice-error inline">
-                <p><?php echo esc_html( $code_snippet_error ); ?></p>
+                    <div class="flygit-snippets-list">
+                        <h3><?php esc_html_e( 'Stored Snippets', 'flygit' ); ?></h3>
+
+                        <?php if ( ! empty( $code_snippets ) ) : ?>
+                            <ul class="flygit-snippet-list">
+                                <?php foreach ( $code_snippets as $snippet ) : ?>
+                                    <?php
+                                    $metadata           = isset( $snippet['metadata'] ) && is_array( $snippet['metadata'] ) ? $snippet['metadata'] : array();
+                                    $snippet_title      = ! empty( $metadata['name'] ) ? $metadata['name'] : $snippet['file'];
+                                    $snippet_description = isset( $metadata['description'] ) ? $metadata['description'] : '';
+                                    $snippet_created    = isset( $metadata['created_at'] ) ? $metadata['created_at'] : '';
+                                    $snippet_status     = isset( $metadata['status'] ) ? $metadata['status'] : '';
+                                    $snippet_updated    = ( isset( $snippet['modified'] ) && $snippet['modified'] ) ? wp_date( 'Y-m-d H:i:s', (int) $snippet['modified'] ) : '';
+                                    $snippet_size       = ( isset( $snippet['size'] ) && is_numeric( $snippet['size'] ) ) ? size_format( (float) $snippet['size'] ) : '';
+                                    ?>
+                                    <li class="flygit-snippet-item">
+                                        <span class="flygit-snippet-title"><?php echo esc_html( $snippet_title ); ?></span>
+                                        <span class="flygit-snippet-meta">
+                                            <span><strong><?php esc_html_e( 'File:', 'flygit' ); ?></strong> <?php echo esc_html( $snippet['file'] ); ?></span>
+                                            <?php if ( ! empty( $snippet_created ) ) : ?>
+                                                <span><strong><?php esc_html_e( 'Created:', 'flygit' ); ?></strong> <?php echo esc_html( $snippet_created ); ?></span>
+                                            <?php endif; ?>
+                                            <?php if ( ! empty( $snippet_updated ) ) : ?>
+                                                <span><strong><?php esc_html_e( 'Updated:', 'flygit' ); ?></strong> <?php echo esc_html( $snippet_updated ); ?></span>
+                                            <?php endif; ?>
+                                            <?php if ( ! empty( $snippet_size ) ) : ?>
+                                                <span><strong><?php esc_html_e( 'Size:', 'flygit' ); ?></strong> <?php echo esc_html( $snippet_size ); ?></span>
+                                            <?php endif; ?>
+                                            <?php if ( ! empty( $snippet_status ) ) : ?>
+                                                <span><strong><?php esc_html_e( 'Status:', 'flygit' ); ?></strong> <?php echo esc_html( $snippet_status ); ?></span>
+                                            <?php endif; ?>
+                                        </span>
+                                        <?php if ( ! empty( $snippet_description ) ) : ?>
+                                            <p class="flygit-snippet-description"><?php echo esc_html( $snippet_description ); ?></p>
+                                        <?php endif; ?>
+                                    </li>
+                                <?php endforeach; ?>
+                            </ul>
+                        <?php else : ?>
+                            <p class="flygit-empty-state">
+                                <span class="dashicons dashicons-media-code" aria-hidden="true"></span>
+                                <?php esc_html_e( 'No snippets imported yet.', 'flygit' ); ?>
+                            </p>
+                        <?php endif; ?>
+                    </div>
+                </div>
+
+                <div class="flygit-card-side" id="flygit-import-snippets">
+                    <div class="flygit-side-card">
+                        <h3><?php esc_html_e( 'Import Snippet Repository', 'flygit' ); ?></h3>
+                        <p class="flygit-side-description"><?php esc_html_e( 'Bring in reusable PHP snippets from any Git repository. FlyGit stores them safely and keeps them synchronised.', 'flygit' ); ?></p>
+
+                        <form class="flygit-form flygit-snippet-form" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+                            <?php wp_nonce_field( 'flygit_import_snippet' ); ?>
+                            <input type="hidden" name="action" value="flygit_import_snippet" />
+
+                            <label>
+                                <?php esc_html_e( 'Display Name', 'flygit' ); ?>
+                                <input type="text" name="name" placeholder="<?php esc_attr_e( 'Code Snippets', 'flygit' ); ?>" />
+                            </label>
+
+                            <label>
+                                <?php esc_html_e( 'Repository URL', 'flygit' ); ?>
+                                <input type="url" name="repository_url" placeholder="https://github.com/owner/repository" required />
+                            </label>
+
+                            <label>
+                                <?php esc_html_e( 'Branch', 'flygit' ); ?>
+                                <input type="text" name="branch" placeholder="main" />
+                            </label>
+
+                            <label>
+                                <?php esc_html_e( 'Access Token (optional)', 'flygit' ); ?>
+                                <input type="password" name="access_token" autocomplete="off" />
+                            </label>
+
+                            <p class="description"><?php esc_html_e( 'All PHP files located in the /php directory will be imported automatically.', 'flygit' ); ?></p>
+                            <p class="description"><?php esc_html_e( 'Provide a GitHub personal access token when importing from private repositories.', 'flygit' ); ?></p>
+
+                            <button type="submit" class="button button-primary flygit-submit-button"><?php esc_html_e( 'Import Snippets', 'flygit' ); ?></button>
+                        </form>
+                    </div>
+                </div>
             </div>
-        <?php endif; ?>
-
-        <div class="flygit-snippets-list">
-            <h3><?php esc_html_e( 'Stored Snippets', 'flygit' ); ?></h3>
-
-            <?php if ( ! empty( $code_snippets ) ) : ?>
-                <ul class="flygit-snippet-list">
-                    <?php foreach ( $code_snippets as $snippet ) : ?>
-                        <?php
-                        $metadata = isset( $snippet['metadata'] ) && is_array( $snippet['metadata'] ) ? $snippet['metadata'] : array();
-                        $snippet_title = ! empty( $metadata['name'] ) ? $metadata['name'] : $snippet['file'];
-                        $snippet_description = isset( $metadata['description'] ) ? $metadata['description'] : '';
-                        $snippet_created = isset( $metadata['created_at'] ) ? $metadata['created_at'] : '';
-                        $snippet_status = isset( $metadata['status'] ) ? $metadata['status'] : '';
-                        $snippet_updated = ( isset( $snippet['modified'] ) && $snippet['modified'] ) ? wp_date( 'Y-m-d H:i:s', (int) $snippet['modified'] ) : '';
-                        $snippet_size = ( isset( $snippet['size'] ) && is_numeric( $snippet['size'] ) ) ? size_format( (float) $snippet['size'] ) : '';
-                        ?>
-                        <li class="flygit-snippet-item">
-                            <span class="flygit-snippet-title"><?php echo esc_html( $snippet_title ); ?></span>
-                            <span class="flygit-snippet-meta">
-                                <span><strong><?php esc_html_e( 'File:', 'flygit' ); ?></strong> <?php echo esc_html( $snippet['file'] ); ?></span>
-                                <?php if ( ! empty( $snippet_created ) ) : ?>
-                                    <span><strong><?php esc_html_e( 'Created:', 'flygit' ); ?></strong> <?php echo esc_html( $snippet_created ); ?></span>
-                                <?php endif; ?>
-                                <?php if ( ! empty( $snippet_updated ) ) : ?>
-                                    <span><strong><?php esc_html_e( 'Updated:', 'flygit' ); ?></strong> <?php echo esc_html( $snippet_updated ); ?></span>
-                                <?php endif; ?>
-                                <?php if ( ! empty( $snippet_size ) ) : ?>
-                                    <span><strong><?php esc_html_e( 'Size:', 'flygit' ); ?></strong> <?php echo esc_html( $snippet_size ); ?></span>
-                                <?php endif; ?>
-                                <?php if ( ! empty( $snippet_status ) ) : ?>
-                                    <span><strong><?php esc_html_e( 'Status:', 'flygit' ); ?></strong> <?php echo esc_html( $snippet_status ); ?></span>
-                                <?php endif; ?>
-                            </span>
-                            <?php if ( ! empty( $snippet_description ) ) : ?>
-                                <p class="flygit-snippet-description"><?php echo esc_html( $snippet_description ); ?></p>
-                            <?php endif; ?>
-                        </li>
-                    <?php endforeach; ?>
-                </ul>
-            <?php else : ?>
-                <p class="description flygit-empty-state">
-                    <span class="dashicons dashicons-media-code" aria-hidden="true"></span>
-                    <?php esc_html_e( 'No snippets imported yet.', 'flygit' ); ?>
-                </p>
-            <?php endif; ?>
-        </div>
+        </section>
     </div>
-    <footer class="flygit-section-footer" id="flygit-import-snippets">
-        <h3><?php esc_html_e( 'Import Snippet Repository', 'flygit' ); ?></h3>
-        <form class="flygit-form flygit-snippet-form" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
-            <?php wp_nonce_field( 'flygit_import_snippet' ); ?>
-            <input type="hidden" name="action" value="flygit_import_snippet" />
-
-            <label>
-                <?php esc_html_e( 'Display Name', 'flygit' ); ?>
-                <input type="text" name="name" placeholder="<?php esc_attr_e( 'Code Snippets', 'flygit' ); ?>" />
-            </label>
-
-            <label>
-                <?php esc_html_e( 'Repository URL', 'flygit' ); ?>
-                <input type="url" name="repository_url" placeholder="https://github.com/owner/repository" required />
-            </label>
-
-            <label>
-                <?php esc_html_e( 'Branch', 'flygit' ); ?>
-                <input type="text" name="branch" placeholder="main" />
-            </label>
-
-            <label>
-                <?php esc_html_e( 'Access Token (optional)', 'flygit' ); ?>
-                <input type="password" name="access_token" autocomplete="off" />
-            </label>
-
-            <p class="description"><?php esc_html_e( 'All PHP files located in the /php directory will be imported automatically.', 'flygit' ); ?></p>
-            <p class="description"><?php esc_html_e( 'Provide a GitHub personal access token when importing from private repositories.', 'flygit' ); ?></p>
-
-            <button type="submit" class="button button-primary">
-                <?php esc_html_e( 'Import Snippets', 'flygit' ); ?>
-            </button>
-        </form>
-    </footer>
-</section>
-
 </div>


### PR DESCRIPTION
## Summary
- rebuild the FlyGit dashboard hero with a new gradient header, quick actions, and live deployment counters
- restructure the theme, plugin, and snippet management areas into split cards that surface details alongside install forms
- refresh the admin stylesheet with modern typography, glassmorphism highlights, and cohesive component styling

## Testing
- php -l includes/views/dashboard.php

------
https://chatgpt.com/codex/tasks/task_e_68cff5f37268832ca412893da2ed51ef